### PR TITLE
[FEAT] User 도메인 CRUD, DTO, Validation, Controller 구현

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/controller/user/UserController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/controller/user/UserController.java
@@ -1,4 +1,55 @@
 package org.example.sharedprompts.controller.user;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.sharedprompts.domain.auth.AuthUser;
+import org.example.sharedprompts.domain.auth.CurrentUser;
+import org.example.sharedprompts.domain.user.service.UserService;
+import org.example.sharedprompts.dto.user.request.PasswordChangeRequestDto;
+import org.example.sharedprompts.dto.user.request.UserUpdateRequestDto;
+import org.example.sharedprompts.dto.user.response.UserResponseDto;
+import org.example.sharedprompts.global.response.CustomResponse;
+import org.example.sharedprompts.global.response.CustomResponseHelper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<CustomResponse<UserResponseDto>> getMyInfo(@CurrentUser AuthUser authUser) {
+        UserResponseDto response = userService.getMyInfo(authUser.getId());
+        return CustomResponseHelper.ok(response);
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<CustomResponse<UserResponseDto>> updateMyInfo(
+            @CurrentUser AuthUser authUser,
+            @Valid @RequestBody UserUpdateRequestDto requestDto
+    ) {
+        UserResponseDto response = userService.updateMyInfo(authUser.getId(), requestDto);
+        return CustomResponseHelper.ok(response);
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<CustomResponse<UserResponseDto>> changePassword(
+            @CurrentUser AuthUser authUser,
+            @Valid @RequestBody PasswordChangeRequestDto requestDto
+    ) {
+        UserResponseDto response = userService.changePassword(authUser.getId(), requestDto);
+        return CustomResponseHelper.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(
+            @PathVariable Long id,
+            @CurrentUser AuthUser authUser
+    ) {
+        userService.deleteUser(id, authUser.getId());
+        return CustomResponseHelper.noContent();
+    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/User.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/User.java
@@ -72,15 +72,6 @@ public class User extends BaseEntity {
         this.age = age;
     }
 
-    public void agreeMarketing() {
-        if (this.terms == null) {
-            this.terms = UserTerms.ofDefault().agreeMarketing();
-        } else {
-            this.terms = this.terms.agreeMarketing();
-        }
-    }
+    public void updateJob(String job) { this.job = job; }
 
-    public boolean hasAgreedRequiredTerms() {
-        return terms != null && terms.isAllRequiredAgreed();
-    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/User.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/User.java
@@ -72,6 +72,8 @@ public class User extends BaseEntity {
         this.age = age;
     }
 
-    public void updateJob(String job) { this.job = job; }
+    public void updateJob(String job) {
+        this.job = job;
+    }
 
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/UserTerms.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/UserTerms.java
@@ -20,18 +20,6 @@ public class UserTerms {
     @Column(nullable = false)
     private boolean marketing = false;
 
-    public boolean isAllRequiredAgreed() {
-        return required && privacy;
-    }
-
-    public UserTerms agreeMarketing() {
-        return UserTerms.builder()
-                .required(this.required)
-                .privacy(this.privacy)
-                .marketing(true)
-                .build();
-    }
-
     public static UserTerms ofDefault() {
         return UserTerms.builder()
                 .required(false)

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/service/UserService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/service/UserService.java
@@ -1,4 +1,17 @@
 package org.example.sharedprompts.domain.user.service;
 
+import org.example.sharedprompts.dto.user.request.PasswordChangeRequestDto;
+import org.example.sharedprompts.dto.user.request.UserUpdateRequestDto;
+import org.example.sharedprompts.dto.user.response.UserResponseDto;
+
 public interface UserService {
+
+    UserResponseDto getMyInfo(Long userId);
+
+    UserResponseDto updateMyInfo(Long userId, UserUpdateRequestDto requestDto);
+
+    UserResponseDto changePassword(Long userId, PasswordChangeRequestDto requestDto);
+
+    void deleteUser(Long targetUserId, Long requesterId);
+
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/service/UserServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/service/UserServiceImpl.java
@@ -1,4 +1,82 @@
 package org.example.sharedprompts.domain.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.example.sharedprompts.domain.user.User;
+import org.example.sharedprompts.domain.user.enums.Provider;
+import org.example.sharedprompts.domain.user.enums.Role;
+import org.example.sharedprompts.domain.user.repository.UserRepository;
+import org.example.sharedprompts.dto.user.request.PasswordChangeRequestDto;
+import org.example.sharedprompts.dto.user.request.UserUpdateRequestDto;
+import org.example.sharedprompts.dto.user.response.UserResponseDto;
+import org.example.sharedprompts.global.exception.ApiException;
+import org.example.sharedprompts.global.exception.ErrorCode;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponseDto getMyInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        return UserResponseDto.from(user);
+    }
+
+    @Override
+    public UserResponseDto updateMyInfo(Long userId, UserUpdateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        User updatedUser = requestDto.applyTo(user);
+
+        return UserResponseDto.from(updatedUser);
+    }
+
+    @Override
+    public UserResponseDto changePassword(Long userId, PasswordChangeRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getProvider() != Provider.LOCAL) {
+            throw new ApiException(ErrorCode.NOT_LOCAL_USER);
+        }
+
+        if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
+            throw new ApiException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getNewPassword());
+        user.changePassword(encodedPassword);
+
+        return UserResponseDto.from(user);
+    }
+
+    @Override
+    public void deleteUser(Long targetUserId, Long requesterId) {
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        // 관리자 또는 본인만 삭제 가능
+        boolean isAdmin = requester.getRole() == Role.ROLE_ADMIN;
+        boolean isSelf = targetUserId.equals(requesterId);
+
+        if (!isAdmin && !isSelf) {
+            throw new ApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        userRepository.delete(targetUser);
+    }
 }
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/service/UserServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/user/service/UserServiceImpl.java
@@ -36,9 +36,9 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
-        User updatedUser = requestDto.applyTo(user);
+        requestDto.applyTo(user);
 
-        return UserResponseDto.from(updatedUser);
+        return UserResponseDto.from(user);
     }
 
     @Override
@@ -54,6 +54,10 @@ public class UserServiceImpl implements UserService {
             throw new ApiException(ErrorCode.INVALID_PASSWORD);
         }
 
+        if (requestDto.getCurrentPassword().equals(requestDto.getNewPassword())) {
+            throw new ApiException(ErrorCode.SAME_AS_CURRENT_PASSWORD);
+        }
+
         String encodedPassword = passwordEncoder.encode(requestDto.getNewPassword());
         user.changePassword(encodedPassword);
 
@@ -65,8 +69,10 @@ public class UserServiceImpl implements UserService {
         User targetUser = userRepository.findById(targetUserId)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
-        User requester = userRepository.findById(requesterId)
-                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+        User requester = targetUserId.equals(requesterId)
+                ? targetUser
+                : userRepository.findById(requesterId)
+                    .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
         // 관리자 또는 본인만 삭제 가능
         boolean isAdmin = requester.getRole() == Role.ROLE_ADMIN;

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/PasswordChangeRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/PasswordChangeRequestDto.java
@@ -1,0 +1,20 @@
+package org.example.sharedprompts.dto.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordChangeRequestDto {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    private String newPassword;
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserRequestDto.java
@@ -1,4 +1,0 @@
-package org.example.sharedprompts.dto.user.request;
-
-public class UserRequestDto {
-}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserTermsRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserTermsRequestDto.java
@@ -1,0 +1,32 @@
+package org.example.sharedprompts.dto.user.request;
+
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.sharedprompts.domain.user.UserTerms;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserTermsRequestDto {
+
+    @AssertTrue(message = "필수 이용약관(required)은 반드시 동의해야 합니다.")
+    private boolean required;
+
+    @AssertTrue(message = "개인정보 처리방침(privacy)은 반드시 동의해야 합니다.")
+    private boolean privacy;
+
+    private boolean marketing;
+
+    public UserTerms toEntity() {
+        return UserTerms.builder()
+                .required(required)
+                .privacy(privacy)
+                .marketing(marketing)
+                .build();
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserUpdateRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserUpdateRequestDto.java
@@ -29,7 +29,7 @@ public class UserUpdateRequestDto {
     private String thumbnail;
     private UserTermsRequestDto userTerms;
 
-    public User applyTo (User user) {
+    public void applyTo (User user) {
         if (nickname != null) user.changeNickname(nickname);
         if (age != null) user.updateAge(age);
         if (job != null) user.updateJob(job);
@@ -37,6 +37,5 @@ public class UserUpdateRequestDto {
         if (userTerms != null) {
             user.agreeToTerms(userTerms.toEntity());
         }
-        return user;
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserUpdateRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/request/UserUpdateRequestDto.java
@@ -1,0 +1,42 @@
+package org.example.sharedprompts.dto.user.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.sharedprompts.domain.user.User;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequestDto {
+
+    @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하로 입력해주세요.")
+    private String nickname;
+
+    @Min(value = 0, message = "나이는 0 이상이어야 합니다.")
+    @Max(value = 150, message = "나이는 150 이하이어야 합니다.")
+    private Integer age;
+
+    @Size(max = 100, message = "직업명은 최대 100자까지 입력 가능합니다.")
+    private String job;
+    private String thumbnail;
+    private UserTermsRequestDto userTerms;
+
+    public User applyTo (User user) {
+        if (nickname != null) user.changeNickname(nickname);
+        if (age != null) user.updateAge(age);
+        if (job != null) user.updateJob(job);
+        if (thumbnail != null) user.updateThumbnail(thumbnail);
+        if (userTerms != null) {
+            user.agreeToTerms(userTerms.toEntity());
+        }
+        return user;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/response/UserResponseDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/response/UserResponseDto.java
@@ -1,4 +1,40 @@
 package org.example.sharedprompts.dto.user.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.sharedprompts.domain.user.User;
+import org.example.sharedprompts.domain.user.enums.Provider;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserResponseDto {
+
+    private Long id;
+    private String email;
+    private Provider provider;
+    private String nickname;
+    private Integer age;
+    private String job;
+    private String thumbnail;
+    private UserTermsResponseDto userTerms;
+
+    public static UserResponseDto from(User user) {
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .provider(user.getProvider())
+                .nickname(user.getNickname())
+                .age(user.getAge())
+                .job(user.getJob())
+                .thumbnail(user.getThumbnail())
+                .userTerms(UserTermsResponseDto.from(user.getTerms()))
+                .build();
+    }
+
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/response/UserTermsResponseDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/response/UserTermsResponseDto.java
@@ -15,6 +15,10 @@ public class UserTermsResponseDto {
     private final boolean marketing;
 
     public static UserTermsResponseDto from(UserTerms userTerms) {
+        if (userTerms == null) {
+            return null;
+        }
+
         return UserTermsResponseDto.builder()
                 .required(userTerms.isRequired())
                 .privacy(userTerms.isPrivacy())

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     // 🔹 USER
     // ==========================
     USER_NOT_FOUND("US00701", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-
+    INVALID_PASSWORD("US00401", HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    NOT_LOCAL_USER("US00601", HttpStatus.FORBIDDEN, "자체 회원가입만 가능한 서비스입니다.."),
     // ==========================
     // 🔹 Auth
     // ==========================

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
     // ==========================
     USER_NOT_FOUND("US00701", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_PASSWORD("US00401", HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    NOT_LOCAL_USER("US00601", HttpStatus.FORBIDDEN, "자체 회원가입만 가능한 서비스입니다.."),
+    NOT_LOCAL_USER("US00601", HttpStatus.FORBIDDEN, "자체 회원가입만 가능한 서비스입니다."),
+    SAME_AS_CURRENT_PASSWORD("US00402", HttpStatus.BAD_REQUEST, "현재 비밀번호와 동일합니다."),
     // ==========================
     // 🔹 Auth
     // ==========================


### PR DESCRIPTION
- UserService / UserServiceImpl: 내 정보 조회, 수정, 비밀번호 변경, 회원 탈퇴 로직 구현
  - 회원 탈퇴: 본인 또는 관리자 권한 체크 적용
  - 비밀번호 변경: 이메일 로그인만 허용, 기존 비밀번호 검증
- DTO 구현
  - UserUpdateRequestDto: nickname, age, job, thumbnail, userTerms, Validation(@Size, @Min, @Max) 적용
  - PasswordChangeRequestDto: currentPassword, newPassword, Validation(@NotBlank, @Size) 적용
- UserController 구현
  - /users/me GET, PATCH
  - /users/me/password PATCH
  - /users/{id} DELETE
  - ResponseEntity<CustomResponse> 사용, CustomResponseHelper로 응답 통일
  - @CurrentUser AuthUser 주입 적용
- User 엔티티 관련 개선
  - 불필요 메서드(agreeMarketing, hasAgreedRequiredTerms) 제거
  - applyTo() 기반 업데이트 적용, Dirty Checking 활용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내 프로필 조회, 프로필 수정, 비밀번호 변경, 계정 삭제 API 추가
  * 프로필 응답 및 요청 DTO 추가로 사용자 정보 입출력 개선
  * 사용자 이용약관 처리 및 약관 관련 입력 DTO 추가

* **품질 개선**
  * 비밀번호 검증 규칙 및 입력 유효성 검사 강화
  * 오류 코드 확장으로 상세한 에러 반환 개선

* **정리**
  * 불필요한 빈 DTO 제거 및 null 안전성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->