### PR TITLE
feat: 댓글/대댓글 기능 전체 구현 및 권한 검증 로직 추가

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/controller/comment/CommentController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/controller/comment/CommentController.java
@@ -1,4 +1,66 @@
 package org.example.sharedprompts.controller.comment;
 
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.sharedprompts.domain.auth.AuthUser;
+import org.example.sharedprompts.domain.auth.CurrentUser;
+import org.example.sharedprompts.domain.comment.service.CommentService;
+import org.example.sharedprompts.dto.comment.request.CommentRequestDto;
+import org.example.sharedprompts.dto.comment.response.CommentResponseDto;
+import org.example.sharedprompts.global.response.CustomResponse;
+import org.example.sharedprompts.global.response.CustomResponseHelper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/prompts/{promptId}/comments")
 public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CustomResponse<CommentResponseDto>> createComment(
+            @PathVariable Long promptId,
+            @Valid @RequestBody CommentRequestDto request,
+            @CurrentUser AuthUser authUser
+    ) {
+        return CustomResponseHelper.created(
+                commentService.createComment(authUser.getId(), promptId, request)
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<CustomResponse<List<CommentResponseDto>>> getComments(
+            @PathVariable Long promptId
+    ) {
+        return CustomResponseHelper.ok(
+                commentService.getCommentsByPrompt(promptId)
+        );
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<CustomResponse<CommentResponseDto>> updateComment(
+            @PathVariable Long promptId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentRequestDto request,
+            @CurrentUser AuthUser authUser
+    ) {
+        return CustomResponseHelper.ok(
+                commentService.updateComment(authUser.getId(), promptId, commentId, request)
+        );
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long promptId,
+            @PathVariable Long commentId,
+            @CurrentUser AuthUser authUser
+    ) {
+        commentService.deleteComment(authUser.getId(), promptId, commentId);
+        return CustomResponseHelper.noContent();
+    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/controller/comment/CommentController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/controller/comment/CommentController.java
@@ -7,6 +7,7 @@ import org.example.sharedprompts.domain.auth.AuthUser;
 import org.example.sharedprompts.domain.auth.CurrentUser;
 import org.example.sharedprompts.domain.comment.service.CommentService;
 import org.example.sharedprompts.dto.comment.request.CommentRequestDto;
+import org.example.sharedprompts.dto.comment.request.CommentUpdateDto;
 import org.example.sharedprompts.dto.comment.response.CommentResponseDto;
 import org.example.sharedprompts.global.response.CustomResponse;
 import org.example.sharedprompts.global.response.CustomResponseHelper;
@@ -46,7 +47,7 @@ public class CommentController {
     public ResponseEntity<CustomResponse<CommentResponseDto>> updateComment(
             @PathVariable Long promptId,
             @PathVariable Long commentId,
-            @Valid @RequestBody CommentRequestDto request,
+            @Valid @RequestBody CommentUpdateDto request,
             @CurrentUser AuthUser authUser
     ) {
         return CustomResponseHelper.ok(

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/Comment.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/Comment.java
@@ -6,6 +6,9 @@ import org.example.sharedprompts.domain.prompt.Prompt;
 import org.example.sharedprompts.domain.user.User;
 import org.example.sharedprompts.global.entity.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -27,5 +30,18 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "prompt_id", nullable = false)
     private Prompt prompt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    @Builder.Default
+    private List<Comment> children = new ArrayList<>();
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/repository/CommentRepository.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/repository/CommentRepository.java
@@ -10,10 +10,12 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("""
-        SELECT c FROM Comment c
-        LEFT JOIN FETCH c.children
+        SELECT DISTINCT c FROM Comment c
+        LEFT JOIN FETCH c.user
+        LEFT JOIN FETCH c.children ch
+        LEFT JOIN FETCH ch.user
         WHERE c.prompt = :prompt AND c.parent IS NULL
         ORDER BY c.createdAt ASC
-""")
+    """)
     List<Comment> findAllByPrompt(@Param("prompt") Prompt prompt);
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/repository/CommentRepository.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,19 @@
 package org.example.sharedprompts.domain.comment.repository;
 
 import org.example.sharedprompts.domain.comment.Comment;
+import org.example.sharedprompts.domain.prompt.Prompt;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("""
+        SELECT c FROM Comment c
+        LEFT JOIN FETCH c.children
+        WHERE c.prompt = :prompt AND c.parent IS NULL
+        ORDER BY c.createdAt ASC
+""")
+    List<Comment> findAllByPrompt(@Param("prompt") Prompt prompt);
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package org.example.sharedprompts.domain.comment.service;
 
 import org.example.sharedprompts.dto.comment.request.CommentRequestDto;
+import org.example.sharedprompts.dto.comment.request.CommentUpdateDto;
 import org.example.sharedprompts.dto.comment.response.CommentResponseDto;
 
 import java.util.List;
@@ -11,7 +12,7 @@ public interface CommentService {
 
     List<CommentResponseDto> getCommentsByPrompt(Long promptId);
 
-    CommentResponseDto updateComment(Long userId, Long promptId, Long commentId, CommentRequestDto requestDto);
+    CommentResponseDto updateComment(Long userId, Long promptId, Long commentId, CommentUpdateDto commentUpdateDto);
 
     void deleteComment(Long userId, Long promptId, Long commentId);
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentService.java
@@ -1,4 +1,17 @@
 package org.example.sharedprompts.domain.comment.service;
 
+import org.example.sharedprompts.dto.comment.request.CommentRequestDto;
+import org.example.sharedprompts.dto.comment.response.CommentResponseDto;
+
+import java.util.List;
+
 public interface CommentService {
+
+    CommentResponseDto createComment(Long userId, Long promptId, CommentRequestDto requestDto);
+
+    List<CommentResponseDto> getCommentsByPrompt(Long promptId);
+
+    CommentResponseDto updateComment(Long userId, Long promptId, Long commentId, CommentRequestDto requestDto);
+
+    void deleteComment(Long userId, Long promptId, Long commentId);
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentServiceImpl.java
@@ -9,6 +9,7 @@ import org.example.sharedprompts.domain.user.User;
 import org.example.sharedprompts.domain.user.repository.UserRepository;
 import org.example.sharedprompts.domain.user.enums.Role;
 import org.example.sharedprompts.dto.comment.request.CommentRequestDto;
+import org.example.sharedprompts.dto.comment.request.CommentUpdateDto;
 import org.example.sharedprompts.dto.comment.response.CommentResponseDto;
 import org.example.sharedprompts.global.exception.ApiException;
 import org.example.sharedprompts.global.exception.ErrorCode;
@@ -61,14 +62,14 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public CommentResponseDto updateComment(Long userId, Long promptId, Long commentId, CommentRequestDto requestDto) {
+    public CommentResponseDto updateComment(Long userId, Long promptId, Long commentId, CommentUpdateDto commentUpdateDto) {
         User user = getUser(userId);
         Prompt prompt = getPrompt(promptId);
         Comment comment = getComment(commentId);
 
         checkCommentPermission(user, prompt, comment);
 
-        comment.updateContent(requestDto.getContent());
+        commentUpdateDto.apply(comment);
 
         return CommentResponseDto.from(comment);
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/comment/service/CommentServiceImpl.java
@@ -1,4 +1,116 @@
 package org.example.sharedprompts.domain.comment.service;
 
+import lombok.RequiredArgsConstructor;
+import org.example.sharedprompts.domain.comment.Comment;
+import org.example.sharedprompts.domain.comment.repository.CommentRepository;
+import org.example.sharedprompts.domain.prompt.Prompt;
+import org.example.sharedprompts.domain.prompt.repository.PromptRepository;
+import org.example.sharedprompts.domain.user.User;
+import org.example.sharedprompts.domain.user.repository.UserRepository;
+import org.example.sharedprompts.domain.user.enums.Role;
+import org.example.sharedprompts.dto.comment.request.CommentRequestDto;
+import org.example.sharedprompts.dto.comment.response.CommentResponseDto;
+import org.example.sharedprompts.global.exception.ApiException;
+import org.example.sharedprompts.global.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PromptRepository promptRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public CommentResponseDto createComment(Long userId, Long promptId, CommentRequestDto requestDto) {
+        User user = getUser(userId);
+        Prompt prompt = getPrompt(promptId);
+
+        Comment parent = null;
+
+        if (requestDto.getParentId() != null) {
+            parent = commentRepository.findById(requestDto.getParentId())
+                    .orElseThrow(() -> new ApiException(ErrorCode.COMMENT_NOT_FOUND));
+
+            if (!parent.getPrompt().equals(prompt)) {
+                throw new ApiException(ErrorCode.COMMENT_NOT_BELONG_TO_PROMPT);
+            }
+        }
+
+        Comment comment = requestDto.toEntity(user, prompt, parent);
+        commentRepository.save(comment);
+
+        return CommentResponseDto.from(comment);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getCommentsByPrompt(Long promptId) {
+        Prompt prompt = getPrompt(promptId);
+
+        List<Comment> rootComments = commentRepository.findAllByPrompt(prompt);
+
+        return rootComments.stream()
+                .map(CommentResponseDto::from)
+                .toList();
+    }
+
+    @Override
+    public CommentResponseDto updateComment(Long userId, Long promptId, Long commentId, CommentRequestDto requestDto) {
+        User user = getUser(userId);
+        Prompt prompt = getPrompt(promptId);
+        Comment comment = getComment(commentId);
+
+        checkCommentPermission(user, prompt, comment);
+
+        comment.updateContent(requestDto.getContent());
+
+        return CommentResponseDto.from(comment);
+    }
+
+    @Override
+    public void deleteComment(Long userId, Long promptId, Long commentId) {
+        User user = getUser(userId);
+        Prompt prompt = getPrompt(promptId);
+        Comment comment = getComment(commentId);
+
+        checkCommentPermission(user, prompt, comment);
+
+        commentRepository.delete(comment);
+    }
+
+    private void checkCommentPermission(User user, Prompt prompt, Comment comment) {
+        if (!comment.getPrompt().equals(prompt)) {
+            throw new ApiException(ErrorCode.COMMENT_NOT_BELONG_TO_PROMPT);
+        }
+
+        boolean isAuthor = comment.getUser().equals(user);
+        boolean isPromptAuthor = prompt.getAuthor().equals(user);
+        boolean isAdmin = user.getRole() == Role.ROLE_ADMIN;
+
+        if (!(isAuthor || isPromptAuthor || isAdmin)) {
+            throw new ApiException(ErrorCode.COMMENT_FORBIDDEN);
+        }
+    }
+
+    private User getUser(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Prompt getPrompt(Long id) {
+        return promptRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.PROMPT_NOT_FOUND));
+    }
+
+    private Comment getComment(Long id) {
+        return commentRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.COMMENT_NOT_FOUND));
+    }
 }
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/comment/request/CommentRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/comment/request/CommentRequestDto.java
@@ -1,4 +1,31 @@
 package org.example.sharedprompts.dto.comment.request;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import org.example.sharedprompts.domain.comment.Comment;
+import org.example.sharedprompts.domain.prompt.Prompt;
+import org.example.sharedprompts.domain.user.User;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentRequestDto {
+
+    @NotBlank(message = "댓글 내용을 입력해주세요.")
+    private String content;
+
+    private Long parentId;
+
+    public Comment toEntity(User user, Prompt prompt, Comment parent) {
+        return Comment.builder()
+                .content(content)
+                .user(user)
+                .prompt(prompt)
+                .parent(parent)
+                .build();
+    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/comment/request/CommentUpdateDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/comment/request/CommentUpdateDto.java
@@ -1,0 +1,22 @@
+package org.example.sharedprompts.dto.comment.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.sharedprompts.domain.comment.Comment;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentUpdateDto {
+
+    @NotBlank(message = "댓글 내용을 입력해주세요.")
+    private String content;
+
+    public void apply(Comment comment) {
+        comment.updateContent(content);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/comment/response/CommentResponseDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/comment/response/CommentResponseDto.java
@@ -1,4 +1,45 @@
 package org.example.sharedprompts.dto.comment.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import org.example.sharedprompts.domain.comment.Comment;
+import org.example.sharedprompts.dto.user.response.UserResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CommentResponseDto {
+
+    private Long id;
+    private String content;
+    private UserResponseDto userResponseDto;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private Long parentId;
+    private List<CommentResponseDto> replies;
+
+    public static CommentResponseDto from(Comment comment) {
+        return CommentResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .userResponseDto(UserResponseDto.from(comment.getUser()))
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .replies(
+                        comment.getChildren().stream()
+                                .map(CommentResponseDto::from)
+                                .toList()
+                )
+                .build();
+    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
@@ -56,6 +56,12 @@ public enum ErrorCode {
     PROMPT_FORBIDDEN("PR00601", HttpStatus.FORBIDDEN, "해당 프롬프트에 대한 접근 권한이 없습니다."),
     AI_GENERATION_FAILED("PR00401", HttpStatus.BAD_REQUEST, "프롬프트 생성에 실패하였습니다."),
 
+    // ==========================
+    // 🔹 COMMENT
+    // ==========================
+    COMMENT_NOT_FOUND("CM00702", HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_BELONG_TO_PROMPT("CM00703", HttpStatus.FORBIDDEN, "댓글이 해당 프롬프트에 속하지 않습니다."),
+    COMMENT_FORBIDDEN("CM00602", HttpStatus.FORBIDDEN, "댓글 수정/삭제 권한이 없습니다."),
     ;
     private final String code;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
- Comment 엔티티에 parent/children 기반 대댓글 구조 적용
- CommentRequestDto에 parentId 필드 추가
- CommentResponseDto에 parentId, replies 트리 구조 반환 기능 추가
- COMMENT_NOT_FOUND, COMMENT_FORBIDDEN, COMMENT_NOT_BELONG_TO_PROMPT 오류 코드 추가
- CommentService 리팩토링:
  - create/update/delete 시 권한 체크 메소드 분리(checkCommentPermission)
  - 부모 댓글이 동일 프롬프트에 속하는지 검증 추가
  - prompt 기반 전체 댓글 트리 조회 기능 구현
- CommentRepository에 fetch join 기반 트리 조회 쿼리 추가
- CommentController 생성 (CRUD API 추가)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 댓글 CRUD API 추가: 작성, 조회(목록), 수정, 삭제 지원
  * 계층형 댓글(대댓글) 지원 및 댓글 답글 정렬(생성순)
  * 댓글 요청/응답 DTO 추가로 내용 검증 및 구조화 개선

* **버그 수정 / 권한**
  * 댓글 존재/소속/권한 관련 명확한 오류 처리 및 권한 검사 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->