### PR TITLE
hotfix: CORS 설정을 Spring Security Filter Chain으로 통합

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/WebMvcConfig.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/WebMvcConfig.java
@@ -1,39 +1,84 @@
 package org.example.sharedprompts.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * CORS 설정
+ *
+ * Spring Security를 사용하는 경우 CORS는 Security Filter Chain에서만 처리됩니다.
+ * WebMvcConfigurer 기반 CORS 설정은 제거되었으며,
+ * 모든 CORS 정책은 Security Filter Chain에서 단일 관리됩니다.
+ *
+ * - Single Source of Truth
+ * - allowCredentials(true) + allowedOriginPatterns 사용
+ */
 @Configuration
-public class WebMvcConfig implements WebMvcConfigurer {
+public class WebMvcConfig {
+
+    private static final List<String> ALLOWED_METHODS =
+            List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS");
+
+    private static final List<String> ALLOWED_HEADERS =
+            List.of("Content-Type", "Authorization", "Accept", "Origin");
+
+    private static final long MAX_AGE = 3600L;
 
     @Value("${cors.allowed-origins}")
     private String corsAllowedOrigins;
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-
+    /**
+     * Origin 설정 파싱 및 검증
+     *
+     * allowCredentials(true) 사용 시
+     * "*" 단독 사용은 금지한다.
+     */
+    private List<String> parseAndValidateOrigins() {
         List<String> origins = Arrays.stream(corsAllowedOrigins.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .toList();
-        boolean isWildcard = origins.size() == 1 && "*".equals(origins.get(0));
-        
-        if (isWildcard) {
+
+        boolean isWildcardOnly =
+                origins.size() == 1 && "*".equals(origins.get(0));
+
+        if (isWildcardOnly) {
             throw new IllegalStateException(
-                "CORS 설정 오류: 와일드카드(*) origin과 allowCredentials(true)는 동시에 사용할 수 없습니다.");
+                    "CORS 설정 오류: allowCredentials(true)에서는 '*' origin을 사용할 수 없습니다."
+            );
         }
 
-        registry.addMapping("/**")
-                .allowedOrigins(origins.toArray(new String[0]))
-                .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
-                .allowedHeaders("Content-Type","Authorization","Accept","Origin")
-                .maxAge(3600)
-                .allowCredentials(true);
+        return origins;
     }
 
+    /**
+     * Spring Security에서 사용할 CORS 설정
+     *
+     * - Preflight(OPTIONS) 요청 포함
+     * - Security Filter Chain 기준 단일 CORS 정책
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        List<String> origins = parseAndValidateOrigins();
+
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(origins);
+        configuration.setAllowedMethods(ALLOWED_METHODS);
+        configuration.setAllowedHeaders(ALLOWED_HEADERS);
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(MAX_AGE);
+
+        UrlBasedCorsConfigurationSource source =
+                new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/jwt/SecurityConfig.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/jwt/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor
@@ -26,47 +27,76 @@ public class SecurityConfig {
     private final OAuth2FailureHandler oAuth2FailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CorsConfigurationSource corsConfigurationSource;
+
+    /* =========================
+       Password / Auth Manager
+       ========================= */
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
     }
+
+    /* =========================
+       JWT Filter Bean
+       ========================= */
+
+    @Bean
+    public JwtAuthFilter jwtAuthFilter() {
+        return new JwtAuthFilter(jwtProvider, tokenRedisService);
+    }
+
+    /* =========================
+       Security Filter Chain
+       ========================= */
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 // CSRF, Session 사용 안 함
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // CORS 설정 (Security Filter Chain 단일 처리)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
 
                 // 인증 예외 처리
-                .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
 
                 // 요청 허용/차단
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/signup","/api/auth/signup",
+                        .requestMatchers(
+                                "/auth/signup","/api/auth/signup",
                                 "/auth/login","/api/auth/login",
                                 "/auth/callback","/api/auth/callback",
                                 "/auth/refresh","/api/auth/refresh",
-                                "/oauth2/**", "/login/**").permitAll()
+                                "/oauth2/**", "/login/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
 
-                // OAuth2 로그인 설정
+                // OAuth2 로그인
                 .oauth2Login(oauth2 -> oauth2
-                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
                         .failureHandler(oAuth2FailureHandler)
                 )
 
-                // JWT Filter 적용
-                .addFilterBefore(new JwtAuthFilter(jwtProvider, tokenRedisService),
-                        UsernamePasswordAuthenticationFilter.class);
+                // JWT 인증 필터
+                .addFilterBefore(
+                        jwtAuthFilter(),
+                        UsernamePasswordAuthenticationFilter.class
+                );
 
         return http.build();
     }


### PR DESCRIPTION
- 문제점
  * WebMvcConfigurer와 Security Filter Chain에서 CORS가 중복 관리됨
  * CORS 정책의 Single Source of Truth 부재
  * allowCredentials(true)와 와일드카드 origin 충돌 가능성

- 변경사항
  * WebMvcConfig.java
    - WebMvcConfigurer 인터페이스 구현 제거
    - addCorsMappings() 메서드 제거
    - CorsConfigurationSource Bean으로 전환
    - CORS 설정 상수 추출 (ALLOWED_METHODS, ALLOWED_HEADERS, MAX_AGE)
    - parseAndValidateOrigins() 메서드로 origin 검증 로직 분리
    - allowedOriginPatterns 사용으로 credential 지원 개선

  * SecurityConfig.java
    - CorsConfigurationSource 의존성 주입 추가
    - Security Filter Chain에 .cors() 설정 통합
    - JwtAuthFilter를 Bean으로 등록하여 재사용성 향상
    - 코드 가독성 향상 (섹션 주석, 메서드 분리)

- 개선 효과
  * CORS 정책 단일 관리로 일관성 보장
  * Security Filter Chain 단계에서 CORS 처리로 안정성 향상
  * Preflight 요청(OPTIONS) 처리 보장
  * allowCredentials(true)와 allowedOriginPatterns 호환성 확보

- 관련 이슈
  * CORS 설정 중복 관리 문제 해결
  * Spring Security Best Practice 준수