### PR TITLE
feat: 팔로우 요청 시 알림 기능 추가

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/event/FollowEvent.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/event/FollowEvent.java
@@ -1,0 +1,12 @@
+package org.example.sharedprompts.domain.follow.event;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FollowEvent {
+
+    // 팔로우 요청 이벤트
+    public record Requested(Long followerId, Long followingId) {}
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
@@ -3,6 +3,7 @@ package org.example.sharedprompts.domain.follow.service;
 import lombok.RequiredArgsConstructor;
 import org.example.sharedprompts.domain.follow.Follow;
 import org.example.sharedprompts.domain.follow.FollowStatus;
+import org.example.sharedprompts.domain.follow.event.FollowEvent;
 import org.example.sharedprompts.domain.follow.repository.FollowRepository;
 import org.example.sharedprompts.domain.user.User;
 import org.example.sharedprompts.domain.user.repository.UserRepository;
@@ -12,6 +13,7 @@ import org.example.sharedprompts.dto.user.response.UserResponseDto;
 import org.example.sharedprompts.global.exception.ApiException;
 import org.example.sharedprompts.global.exception.ErrorCode;
 import org.example.sharedprompts.global.response.PageResponse;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +26,7 @@ public class FollowServiceImpl implements FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -40,6 +43,8 @@ public class FollowServiceImpl implements FollowService {
         Follow follow = new Follow(followerId, followingId);
         try {
             followRepository.save(follow);
+            // 팔로우 요청 이벤트 발행
+            eventPublisher.publishEvent(new FollowEvent.Requested(followerId, followingId));
         } catch (DataIntegrityViolationException e) {
             throw new ApiException(ErrorCode.FOLLOW_ALREADY_EXISTS);
         }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/NotificationType.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/NotificationType.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum NotificationType {
     COMMENT,    // 댓글 알림
     LIKE,       // 좋아요 알림
-    FAVORITE    // 즐겨찾기 알림
+    FAVORITE,   // 즐겨찾기 알림
+    FOLLOW      // 팔로우 알림
 }
 
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/RelatedEntityType.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/RelatedEntityType.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RelatedEntityType {
     PROMPT("프롬프트"),
-    COMMENT("댓글");
+    COMMENT("댓글"),
+    USER("사용자");
 
     private final String displayName;
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/event/NotificationEventListener.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/event/NotificationEventListener.java
@@ -3,6 +3,7 @@ package org.example.sharedprompts.domain.notification.event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.domain.comment.event.CommentEvent;
+import org.example.sharedprompts.domain.follow.event.FollowEvent;
 import org.example.sharedprompts.domain.like.event.LikeEvent;
 import org.example.sharedprompts.domain.notification.processor.NotificationEventProcessor;
 import org.springframework.stereotype.Component;
@@ -55,6 +56,18 @@ public class NotificationEventListener {
             notificationEventProcessor.processCommentLiked(event);
         } catch (Exception e) {
             log.error("Failed to handle comment liked event: {}", event, e);
+        }
+    }
+
+    /**
+     * 팔로우 요청 이벤트 처리
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFollowRequested(FollowEvent.Requested event) {
+        try {
+            notificationEventProcessor.processFollowRequested(event);
+        } catch (Exception e) {
+            log.error("Failed to handle follow requested event: {}", event, e);
         }
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/processor/NotificationEventProcessor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/processor/NotificationEventProcessor.java
@@ -6,6 +6,7 @@ import org.example.sharedprompts.domain.comment.Comment;
 import org.example.sharedprompts.domain.comment.event.CommentEvent;
 import org.example.sharedprompts.domain.comment.repository.CommentRepository;
 import org.example.sharedprompts.domain.favorite.event.FavoriteEvent;
+import org.example.sharedprompts.domain.follow.event.FollowEvent;
 import org.example.sharedprompts.domain.like.event.LikeEvent;
 import org.example.sharedprompts.domain.notification.enums.NotificationType;
 import org.example.sharedprompts.domain.notification.enums.RelatedEntityType;
@@ -211,6 +212,40 @@ public class NotificationEventProcessor {
                 RelatedEntityType.PROMPT,
                 event.promptId(),
                 event.userId(),
+                message
+        );
+        publishNotification(notification);
+    }
+
+    /**
+     * 팔로우 요청 이벤트 처리
+     * - 팔로우 대상자(followingId)에게 알림 (본인이 팔로우 요청한 경우 제외)
+     */
+    public void processFollowRequested(FollowEvent.Requested event) {
+        User followingUser = getUser(event.followingId());
+        User followerUser = getUser(event.followerId());
+
+        // 팔로우 대상자에게 알림 (본인이 팔로우 요청한 경우 제외)
+        if (event.followerId().equals(event.followingId())) {
+            return; // 본인이 자신을 팔로우 요청한 경우 알림 제외
+        }
+        
+        if (!isNotificationEnabled(followingUser, NotificationType.FOLLOW)) {
+            return; // 알림 설정이 꺼져 있는 경우
+        }
+        
+        // relatedEntityId는 팔로우 대상자(followingId)로 설정
+        if (isDuplicateNotification(followingUser.getId(), NotificationType.FOLLOW, event.followingId())) {
+            return; // 중복 알림인 경우
+        }
+        
+        String message = messageFormatter.formatFollowMessage(followerUser);
+        NotificationMessage notification = createNotification(
+                followingUser.getId(),
+                NotificationType.FOLLOW,
+                RelatedEntityType.USER,
+                event.followingId(),
+                event.followerId(),
                 message
         );
         publishNotification(notification);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/service/NotificationMessageFormatter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/service/NotificationMessageFormatter.java
@@ -33,6 +33,7 @@ public class NotificationMessageFormatter {
         registerTemplate("prompt_like", this::formatPromptLikeMessage);
         registerTemplate("comment_like", this::formatCommentLikeMessage);
         registerTemplate("prompt_favorite", this::formatPromptFavoriteMessage);
+        registerTemplate("follow", this::formatFollowMessage);
     }
 
     /**
@@ -79,6 +80,13 @@ public class NotificationMessageFormatter {
      */
     public String formatPromptFavoriteMessage(User favoriteUser) {
         return String.format("%s님이 당신의 프롬프트를 즐겨찾기에 추가했습니다.", favoriteUser.getNickname());
+    }
+
+    /**
+     * 팔로우 알림 메시지 생성
+     */
+    public String formatFollowMessage(User follower) {
+        return String.format("%s님이 팔로우를 요청했습니다.", follower.getNickname());
     }
 
     /**


### PR DESCRIPTION
- FollowEvent 클래스 생성 (팔로우 요청 이벤트)
- NotificationType enum에 FOLLOW 타입 추가
- RelatedEntityType enum에 USER 타입 추가
- NotificationMessageFormatter에 팔로우 메시지 포맷 추가
- NotificationEventProcessor에 processFollowRequested 메서드 추가
- NotificationEventListener에 팔로우 이벤트 리스너 추가
- FollowServiceImpl에서 팔로우 요청 시 이벤트 발행

팔로우 요청이 들어오면 대상 사용자에게 알림이 발송됩니다.