### PR TITLE
feat: 팔로우 요청 시 알림 기능 추가

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/Follow.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/Follow.java
@@ -3,6 +3,7 @@ package org.example.sharedprompts.domain.follow;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.sharedprompts.global.entity.BaseEntity;
 
 @Entity
 @Table(
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor
-public class Follow {
+public class Follow extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,6 +42,18 @@ public class Follow {
 
     public void markBlocked() {
         this.status = FollowStatus.BLOCKED;
+    }
+
+    public void markRejected() {
+        this.status = FollowStatus.REJECTED;
+    }
+
+    public void markCancelled() {
+        this.status = FollowStatus.CANCELLED;
+    }
+
+    public void markPending() {
+        this.status = FollowStatus.PENDING;
     }
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/FollowStatus.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/FollowStatus.java
@@ -1,8 +1,10 @@
 package org.example.sharedprompts.domain.follow;
 
 public enum FollowStatus {
-    PENDING,    // 요청 대기
+    PENDING,    // 팔로우 요청 대기
     FOLLOWING,  // 팔로우 확정
+    REJECTED,   // 요청 거절됨
+    CANCELLED,  // 사용자가 요청 취소
     BLOCKED;    // 차단
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/event/FollowEvent.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/event/FollowEvent.java
@@ -1,0 +1,12 @@
+package org.example.sharedprompts.domain.follow.event;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FollowEvent {
+
+    // 팔로우 요청 이벤트
+    public record Requested(Long followerId, Long followingId) {}
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
@@ -36,7 +36,20 @@ public class FollowServiceImpl implements FollowService {
         validateUserExists(followingId);
         validateNotSelfFollow(followerId, followingId);
 
-        if (followRepository.existsByFollowerIdAndFollowingId(followerId, followingId)) {
+        Follow existingFollow = followRepository
+                .findByFollowerIdAndFollowingId(followerId, followingId)
+                .orElse(null);
+
+        if (existingFollow != null) {
+            FollowStatus currentStatus = existingFollow.getStatus();
+            // REJECTED, CANCELLED 상태면 PENDING으로 재요청 가능
+            if (currentStatus == FollowStatus.REJECTED || currentStatus == FollowStatus.CANCELLED) {
+                existingFollow.markPending();
+                followRepository.save(existingFollow);
+                eventPublisher.publishEvent(new FollowEvent.Requested(followerId, followingId));
+                return;
+            }
+            // 다른 상태면 이미 존재하는 것으로 처리
             throw new ApiException(ErrorCode.FOLLOW_ALREADY_EXISTS);
         }
 
@@ -74,7 +87,8 @@ public class FollowServiceImpl implements FollowService {
             throw new ApiException(ErrorCode.FOLLOW_NOT_PENDING);
         }
 
-        followRepository.delete(follow);
+        follow.markRejected();
+        followRepository.save(follow);
     }
 
     @Override
@@ -103,7 +117,8 @@ public class FollowServiceImpl implements FollowService {
             throw new ApiException(ErrorCode.FOLLOW_NOT_BLOCKED);
         }
 
-        followRepository.delete(follow);
+        follow.markPending();
+        followRepository.save(follow);
     }
 
     @Override
@@ -111,7 +126,16 @@ public class FollowServiceImpl implements FollowService {
     public void unfollow(Long followerId, Long followingId) {
         validateIds(followerId, followingId);
         Follow follow = findFollow(followerId, followingId);
-        followRepository.delete(follow);
+        
+        FollowStatus currentStatus = follow.getStatus();
+        // PENDING 또는 FOLLOWING 상태에서 취소하면 CANCELLED로 변경 (재요청 가능하도록 기록 유지)
+        if (currentStatus == FollowStatus.PENDING || currentStatus == FollowStatus.FOLLOWING) {
+            follow.markCancelled();
+            followRepository.save(follow);
+        } else {
+            // REJECTED, CANCELLED, BLOCKED 등의 다른 상태에서는 삭제
+            followRepository.delete(follow);
+        }
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
@@ -3,6 +3,7 @@ package org.example.sharedprompts.domain.follow.service;
 import lombok.RequiredArgsConstructor;
 import org.example.sharedprompts.domain.follow.Follow;
 import org.example.sharedprompts.domain.follow.FollowStatus;
+import org.example.sharedprompts.domain.follow.event.FollowEvent;
 import org.example.sharedprompts.domain.follow.repository.FollowRepository;
 import org.example.sharedprompts.domain.user.User;
 import org.example.sharedprompts.domain.user.repository.UserRepository;
@@ -12,6 +13,7 @@ import org.example.sharedprompts.dto.user.response.UserResponseDto;
 import org.example.sharedprompts.global.exception.ApiException;
 import org.example.sharedprompts.global.exception.ErrorCode;
 import org.example.sharedprompts.global.response.PageResponse;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +26,7 @@ public class FollowServiceImpl implements FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -40,6 +43,8 @@ public class FollowServiceImpl implements FollowService {
         Follow follow = new Follow(followerId, followingId);
         try {
             followRepository.save(follow);
+            // 팔로우 요청 이벤트 발행
+            eventPublisher.publishEvent(new FollowEvent.Requested(followerId, followingId));
         } catch (DataIntegrityViolationException e) {
             throw new ApiException(ErrorCode.FOLLOW_ALREADY_EXISTS);
         }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
@@ -14,7 +14,6 @@ import org.example.sharedprompts.global.exception.ApiException;
 import org.example.sharedprompts.global.exception.ErrorCode;
 import org.example.sharedprompts.global.response.PageResponse;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,53 +21,52 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class FollowServiceImpl implements FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Override
-    @Transactional
-    public void requestFollow(Long followerId, Long followingId) {
-        validateIds(followerId, followingId);
-        validateUserExists(followerId);
-        validateUserExists(followingId);
-        validateNotSelfFollow(followerId, followingId);
+    /* ================= 팔로우 요청 ================= */
 
-        Follow existingFollow = followRepository
+    @Override
+    public void requestFollow(Long followerId, Long followingId) {
+        validateRequest(followerId, followingId);
+
+        Follow follow = followRepository
                 .findByFollowerIdAndFollowingId(followerId, followingId)
                 .orElse(null);
 
-        if (existingFollow != null) {
-            FollowStatus currentStatus = existingFollow.getStatus();
-            // REJECTED, CANCELLED 상태면 PENDING으로 재요청 가능
-            if (currentStatus == FollowStatus.REJECTED || currentStatus == FollowStatus.CANCELLED) {
-                existingFollow.markPending();
-                followRepository.save(existingFollow);
-                eventPublisher.publishEvent(new FollowEvent.Requested(followerId, followingId));
-                return;
-            }
-            // 다른 상태면 이미 존재하는 것으로 처리
-            throw new ApiException(ErrorCode.FOLLOW_ALREADY_EXISTS);
+        if (follow == null) {
+            follow = new Follow(followerId, followingId);
+            followRepository.save(follow);
+            eventPublisher.publishEvent(new FollowEvent.Requested(followerId, followingId));
+            return;
         }
 
-        Follow follow = new Follow(followerId, followingId);
-        try {
+        FollowStatus status = follow.getStatus();
+
+        if (status == FollowStatus.REJECTED || status == FollowStatus.CANCELLED) {
+            follow.markPending();
             followRepository.save(follow);
-            // 팔로우 요청 이벤트 발행
             eventPublisher.publishEvent(new FollowEvent.Requested(followerId, followingId));
-        } catch (DataIntegrityViolationException e) {
-            throw new ApiException(ErrorCode.FOLLOW_ALREADY_EXISTS);
+            return;
         }
+
+        if (status == FollowStatus.BLOCKED) {
+            throw new ApiException(ErrorCode.FOLLOW_BLOCKED);
+        }
+
+        throw new ApiException(ErrorCode.FOLLOW_ALREADY_EXISTS);
     }
 
+    /* ================= 요청 수락 / 거절 ================= */
+
     @Override
-    @Transactional
     public void acceptFollow(Long followerId, Long followingId) {
-        validateIds(followerId, followingId);
         Follow follow = findFollow(followerId, followingId);
-        
+
         if (follow.getStatus() != FollowStatus.PENDING) {
             throw new ApiException(ErrorCode.FOLLOW_NOT_PENDING);
         }
@@ -78,11 +76,9 @@ public class FollowServiceImpl implements FollowService {
     }
 
     @Override
-    @Transactional
     public void rejectFollow(Long followerId, Long followingId) {
-        validateIds(followerId, followingId);
         Follow follow = findFollow(followerId, followingId);
-        
+
         if (follow.getStatus() != FollowStatus.PENDING) {
             throw new ApiException(ErrorCode.FOLLOW_NOT_PENDING);
         }
@@ -91,13 +87,30 @@ public class FollowServiceImpl implements FollowService {
         followRepository.save(follow);
     }
 
+    /* ================= 언팔 / 차단 ================= */
+
     @Override
-    @Transactional
+    public void unfollow(Long followerId, Long followingId) {
+        Follow follow = findFollow(followerId, followingId);
+
+        FollowStatus status = follow.getStatus();
+
+        if (status == FollowStatus.BLOCKED) {
+            throw new ApiException(ErrorCode.FOLLOW_BLOCKED);
+        }
+
+        if (status == FollowStatus.CANCELLED || status == FollowStatus.REJECTED) {
+            // 이미 종료된 관계 → no-op
+            return;
+        }
+
+        follow.markCancelled();
+        followRepository.save(follow);
+    }
+
+    @Override
     public void blockFollow(Long followerId, Long followingId) {
-        validateIds(followerId, followingId);
-        validateUserExists(followerId);
-        validateUserExists(followingId);
-        validateNotSelfFollow(followerId, followingId);
+        validateRequest(followerId, followingId);
 
         Follow follow = followRepository
                 .findByFollowerIdAndFollowingId(followerId, followingId)
@@ -108,11 +121,9 @@ public class FollowServiceImpl implements FollowService {
     }
 
     @Override
-    @Transactional
     public void unblockFollow(Long followerId, Long followingId) {
-        validateIds(followerId, followingId);
         Follow follow = findFollow(followerId, followingId);
-        
+
         if (follow.getStatus() != FollowStatus.BLOCKED) {
             throw new ApiException(ErrorCode.FOLLOW_NOT_BLOCKED);
         }
@@ -121,32 +132,13 @@ public class FollowServiceImpl implements FollowService {
         followRepository.save(follow);
     }
 
-    @Override
-    @Transactional
-    public void unfollow(Long followerId, Long followingId) {
-        validateIds(followerId, followingId);
-        Follow follow = findFollow(followerId, followingId);
-        
-        FollowStatus currentStatus = follow.getStatus();
-        // BLOCKED 상태는 unfollow로 제거할 수 없음
-        if (currentStatus == FollowStatus.BLOCKED) {
-            throw new ApiException(ErrorCode.CANNOT_UNFOLLOW_BLOCKED);
-        }
-        
-        // PENDING 또는 FOLLOWING 상태에서 취소하면 CANCELLED로 변경 (재요청 가능하도록 기록 유지)
-        if (currentStatus == FollowStatus.PENDING || currentStatus == FollowStatus.FOLLOWING) {
-            follow.markCancelled();
-            followRepository.save(follow);
-        } else {
-            // REJECTED, CANCELLED 상태에서는 삭제
-            followRepository.delete(follow);
-        }
-    }
+    /* ================= 조회 ================= */
 
     @Override
     @Transactional(readOnly = true)
     public FollowResponseDto getFollowStatus(Long followerId, Long followingId) {
         validateIds(followerId, followingId);
+
         return followRepository
                 .findByFollowerIdAndFollowingId(followerId, followingId)
                 .map(follow -> FollowResponseDto.from(follow.getStatus()))
@@ -155,45 +147,55 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponse<UserResponseDto> getFollowers(Long userId, FollowStatus status, Pageable pageable) {
-        Page<User> page = followRepository.findFollowersByUserIdAndStatus(userId, status, pageable);
+    public PageResponse<UserResponseDto> getFollowers(
+            Long userId, FollowStatus status, Pageable pageable) {
+
+        Page<User> page =
+                followRepository.findFollowersByUserIdAndStatus(userId, status, pageable);
+
         return PageResponse.of(page.map(UserResponseDto::from));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponse<UserResponseDto> getFollowing(Long userId, FollowStatus status, Pageable pageable) {
-        Page<User> page = followRepository.findFollowingByUserIdAndStatus(userId, status, pageable);
+    public PageResponse<UserResponseDto> getFollowing(
+            Long userId, FollowStatus status, Pageable pageable) {
+
+        Page<User> page =
+                followRepository.findFollowingByUserIdAndStatus(userId, status, pageable);
+
         return PageResponse.of(page.map(UserResponseDto::from));
     }
 
     @Override
     @Transactional(readOnly = true)
     public FollowCountResponseDto getFollowCount(Long userId, FollowStatus status) {
-        Long followersCount = followRepository.countFollowersByUserIdAndStatus(userId, status);
-        Long followingCount = followRepository.countFollowingByUserIdAndStatus(userId, status);
-        
         return FollowCountResponseDto.builder()
-                .followersCount(followersCount)
-                .followingCount(followingCount)
+                .followersCount(
+                        followRepository.countFollowersByUserIdAndStatus(userId, status))
+                .followingCount(
+                        followRepository.countFollowingByUserIdAndStatus(userId, status))
                 .build();
+    }
+
+    /* ================= 검증 / 헬퍼 ================= */
+
+    private void validateRequest(Long followerId, Long followingId) {
+        validateIds(followerId, followingId);
+
+        if (followerId.equals(followingId)) {
+            throw new ApiException(ErrorCode.CANNOT_FOLLOW_SELF);
+        }
+
+        if (!userRepository.existsById(followerId)
+                || !userRepository.existsById(followingId)) {
+            throw new ApiException(ErrorCode.USER_NOT_FOUND);
+        }
     }
 
     private void validateIds(Long followerId, Long followingId) {
         if (followerId == null || followingId == null) {
             throw new ApiException(ErrorCode.FOLLOW_IDS_REQUIRED);
-        }
-    }
-
-    private void validateUserExists(Long userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new ApiException(ErrorCode.USER_NOT_FOUND);
-        }
-    }
-
-    private void validateNotSelfFollow(Long followerId, Long followingId) {
-        if (followerId.equals(followingId)) {
-            throw new ApiException(ErrorCode.CANNOT_FOLLOW_SELF);
         }
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/follow/service/FollowServiceImpl.java
@@ -128,12 +128,17 @@ public class FollowServiceImpl implements FollowService {
         Follow follow = findFollow(followerId, followingId);
         
         FollowStatus currentStatus = follow.getStatus();
+        // BLOCKED 상태는 unfollow로 제거할 수 없음
+        if (currentStatus == FollowStatus.BLOCKED) {
+            throw new ApiException(ErrorCode.CANNOT_UNFOLLOW_BLOCKED);
+        }
+        
         // PENDING 또는 FOLLOWING 상태에서 취소하면 CANCELLED로 변경 (재요청 가능하도록 기록 유지)
         if (currentStatus == FollowStatus.PENDING || currentStatus == FollowStatus.FOLLOWING) {
             follow.markCancelled();
             followRepository.save(follow);
         } else {
-            // REJECTED, CANCELLED, BLOCKED 등의 다른 상태에서는 삭제
+            // REJECTED, CANCELLED 상태에서는 삭제
             followRepository.delete(follow);
         }
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/NotificationType.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/NotificationType.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum NotificationType {
     COMMENT,    // 댓글 알림
     LIKE,       // 좋아요 알림
-    FAVORITE    // 즐겨찾기 알림
+    FAVORITE,   // 즐겨찾기 알림
+    FOLLOW      // 팔로우 알림
 }
 
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/RelatedEntityType.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/enums/RelatedEntityType.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RelatedEntityType {
     PROMPT("프롬프트"),
-    COMMENT("댓글");
+    COMMENT("댓글"),
+    USER("사용자");
 
     private final String displayName;
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/event/NotificationEventListener.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/event/NotificationEventListener.java
@@ -3,6 +3,7 @@ package org.example.sharedprompts.domain.notification.event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.domain.comment.event.CommentEvent;
+import org.example.sharedprompts.domain.follow.event.FollowEvent;
 import org.example.sharedprompts.domain.like.event.LikeEvent;
 import org.example.sharedprompts.domain.notification.processor.NotificationEventProcessor;
 import org.springframework.stereotype.Component;
@@ -55,6 +56,18 @@ public class NotificationEventListener {
             notificationEventProcessor.processCommentLiked(event);
         } catch (Exception e) {
             log.error("Failed to handle comment liked event: {}", event, e);
+        }
+    }
+
+    /**
+     * 팔로우 요청 이벤트 처리
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFollowRequested(FollowEvent.Requested event) {
+        try {
+            notificationEventProcessor.processFollowRequested(event);
+        } catch (Exception e) {
+            log.error("Failed to handle follow requested event: {}", event, e);
         }
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/processor/NotificationEventProcessor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/processor/NotificationEventProcessor.java
@@ -6,6 +6,7 @@ import org.example.sharedprompts.domain.comment.Comment;
 import org.example.sharedprompts.domain.comment.event.CommentEvent;
 import org.example.sharedprompts.domain.comment.repository.CommentRepository;
 import org.example.sharedprompts.domain.favorite.event.FavoriteEvent;
+import org.example.sharedprompts.domain.follow.event.FollowEvent;
 import org.example.sharedprompts.domain.like.event.LikeEvent;
 import org.example.sharedprompts.domain.notification.enums.NotificationType;
 import org.example.sharedprompts.domain.notification.enums.RelatedEntityType;
@@ -211,6 +212,40 @@ public class NotificationEventProcessor {
                 RelatedEntityType.PROMPT,
                 event.promptId(),
                 event.userId(),
+                message
+        );
+        publishNotification(notification);
+    }
+
+    /**
+     * 팔로우 요청 이벤트 처리
+     * - 팔로우 대상자(followingId)에게 알림 (본인이 팔로우 요청한 경우 제외)
+     */
+    public void processFollowRequested(FollowEvent.Requested event) {
+        User followingUser = getUser(event.followingId());
+        User followerUser = getUser(event.followerId());
+
+        // 팔로우 대상자에게 알림 (본인이 팔로우 요청한 경우 제외)
+        if (event.followerId().equals(event.followingId())) {
+            return; // 본인이 자신을 팔로우 요청한 경우 알림 제외
+        }
+        
+        if (!isNotificationEnabled(followingUser, NotificationType.FOLLOW)) {
+            return; // 알림 설정이 꺼져 있는 경우
+        }
+        
+        // relatedEntityId는 팔로우 대상자(followingId)로 설정
+        if (isDuplicateNotification(followingUser.getId(), NotificationType.FOLLOW, event.followingId())) {
+            return; // 중복 알림인 경우
+        }
+        
+        String message = messageFormatter.formatFollowMessage(followerUser);
+        NotificationMessage notification = createNotification(
+                followingUser.getId(),
+                NotificationType.FOLLOW,
+                RelatedEntityType.USER,
+                event.followingId(),
+                event.followerId(),
                 message
         );
         publishNotification(notification);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/processor/NotificationEventProcessor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/processor/NotificationEventProcessor.java
@@ -234,8 +234,8 @@ public class NotificationEventProcessor {
             return; // 알림 설정이 꺼져 있는 경우
         }
         
-        // relatedEntityId는 팔로우 대상자(followingId)로 설정
-        if (isDuplicateNotification(followingUser.getId(), NotificationType.FOLLOW, event.followingId())) {
+        // relatedEntityId는 팔로워 ID(followerId)로 설정하여 누가 팔로우했는지 명확히 함
+        if (isDuplicateNotification(followingUser.getId(), NotificationType.FOLLOW, event.followerId())) {
             return; // 중복 알림인 경우
         }
         
@@ -244,7 +244,7 @@ public class NotificationEventProcessor {
                 followingUser.getId(),
                 NotificationType.FOLLOW,
                 RelatedEntityType.USER,
-                event.followingId(),
+                event.followerId(),
                 event.followerId(),
                 message
         );

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/service/NotificationMessageFormatter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/notification/service/NotificationMessageFormatter.java
@@ -33,6 +33,7 @@ public class NotificationMessageFormatter {
         registerTemplate("prompt_like", this::formatPromptLikeMessage);
         registerTemplate("comment_like", this::formatCommentLikeMessage);
         registerTemplate("prompt_favorite", this::formatPromptFavoriteMessage);
+        registerTemplate("follow", this::formatFollowMessage);
     }
 
     /**
@@ -79,6 +80,13 @@ public class NotificationMessageFormatter {
      */
     public String formatPromptFavoriteMessage(User favoriteUser) {
         return String.format("%s님이 당신의 프롬프트를 즐겨찾기에 추가했습니다.", favoriteUser.getNickname());
+    }
+
+    /**
+     * 팔로우 알림 메시지 생성
+     */
+    public String formatFollowMessage(User follower) {
+        return String.format("%s님이 팔로우를 요청했습니다.", follower.getNickname());
     }
 
     /**

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
@@ -92,6 +92,7 @@ public enum ErrorCode {
     CANNOT_FOLLOW_SELF("FW00403", HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
     FOLLOW_NOT_BLOCKED("FW00404", HttpStatus.BAD_REQUEST, "차단 상태가 아닌 관계는 차단 해제할 수 없습니다."),
     FOLLOW_NOT_PENDING("FW00405", HttpStatus.BAD_REQUEST, "대기 상태가 아닌 관계는 거부할 수 없습니다."),
+    CANNOT_UNFOLLOW_BLOCKED("FW00406", HttpStatus.FORBIDDEN, "차단된 관계는 언팔로우할 수 없습니다."),
     FOLLOW_NOT_FOUND("FW00701", HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다."),
 
     // ==========================

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/ErrorCode.java
@@ -92,7 +92,7 @@ public enum ErrorCode {
     CANNOT_FOLLOW_SELF("FW00403", HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
     FOLLOW_NOT_BLOCKED("FW00404", HttpStatus.BAD_REQUEST, "차단 상태가 아닌 관계는 차단 해제할 수 없습니다."),
     FOLLOW_NOT_PENDING("FW00405", HttpStatus.BAD_REQUEST, "대기 상태가 아닌 관계는 거부할 수 없습니다."),
-    CANNOT_UNFOLLOW_BLOCKED("FW00406", HttpStatus.FORBIDDEN, "차단된 관계는 언팔로우할 수 없습니다."),
+    FOLLOW_BLOCKED("FW00406", HttpStatus.FORBIDDEN, "차단된 관계는 작업할 수 없습니다."),
     FOLLOW_NOT_FOUND("FW00701", HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다."),
 
     // ==========================


### PR DESCRIPTION
- FollowEvent 클래스 생성 (팔로우 요청 이벤트)
- NotificationType enum에 FOLLOW 타입 추가
- RelatedEntityType enum에 USER 타입 추가
- NotificationMessageFormatter에 팔로우 메시지 포맷 추가
- NotificationEventProcessor에 processFollowRequested 메서드 추가
- NotificationEventListener에 팔로우 이벤트 리스너 추가
- FollowServiceImpl에서 팔로우 요청 시 이벤트 발행

팔로우 요청이 들어오면 대상 사용자에게 알림이 발송됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 팔로우 요청 시 이벤트 발행 및 이를 수신하는 알림 처리 경로가 추가되었습니다.
  * 팔로우 알림 생성 로직이 도입되어 알림 설정·중복 필터링을 반영합니다.
  * 팔로우 상태에 REJECTED·CANCELLED가 추가되어 상태 전환이 명확해졌습니다.
* **버그 수정 / 동작 변경**
  * 팔로우 요청·수락·거절·언팔·차단 흐름을 상태 기반으로 정비하고 예외 처리를 개선했습니다.
* **문구/알림**
  * 팔로우 전용 알림 메시지 포맷이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->