### PR TITLE
feat: Rate Limit 필터의 Redis 장애 처리 개선

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,26 +1,28 @@
 package org.example.sharedprompts.auth.jwt.filter;
 
-import io.jsonwebtoken.Claims;
+import java.io.IOException;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import org.example.sharedprompts.auth.jwt.model.PrincipalDetails;
 import org.example.sharedprompts.auth.jwt.service.JwtTokenService;
 import org.example.sharedprompts.auth.jwt.util.JwtErrorResponseWriter;
 import org.example.sharedprompts.global.exception.ErrorCode;
 import org.example.sharedprompts.global.redis.TokenRedisService;
 import org.example.sharedprompts.global.util.SensitiveDataMasker;
-import org.jetbrains.annotations.NotNull;
-import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 /**
  * JWT 인증 필터
@@ -93,19 +95,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // ==================== 2단계: Redis 토큰 검증 (선택적, Fail-Open) ====================
         // Redis는 선택 검증 단계로 처리: Redis 장애 시에도 JWT 서명 검증 통과 시 인증 허용
-        boolean isRedisTokenValid;
-        try {
-            isRedisTokenValid = tokenRedisService.isAccessTokenValid(token);
-        } catch (Exception e) {
-            // Redis 장애 시 Fail-Open: JWT 서명 검증은 이미 통과했으므로 인증 허용
-            // Circuit Breaker가 Open 상태이거나 DataAccessException 발생 시
-            log.warn("Redis 토큰 검증 실패 (Redis 장애로 추정): userId={}, token={}, Fail-Open 적용하여 인증 허용", 
-                    userId, SensitiveDataMasker.maskToken(token), e);
-            isRedisTokenValid = true; // Fail-Open: Redis 장애 시 토큰을 유효한 것으로 간주
-        }
+        // TokenRedisService의 Circuit Breaker fallback이 Fail-Open 정책을 적용하므로
+        // 예외가 발생하지 않고 true를 반환합니다.
+        boolean isRedisTokenValid = tokenRedisService.isAccessTokenValid(token);
 
         if (!isRedisTokenValid) {
             // Redis에서 토큰이 없거나 만료된 경우 (Redis가 정상 동작 중일 때만)
+            // Circuit Breaker가 Open 상태이거나 Redis 장애 시에는 fallback에서 true를 반환하므로
+            // 이 분기는 Redis가 정상 동작 중이고 토큰이 실제로 없거나 만료된 경우에만 실행됩니다.
             log.warn("Redis 토큰 검증 실패: userId={}, token={}, 토큰이 Redis에 없거나 만료됨", 
                     userId, SensitiveDataMasker.maskToken(token));
             handleInvalidToken(token, response, "Redis 토큰 검증 실패: userId=%s", userId);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/AbstractRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/AbstractRateLimitFilter.java
@@ -51,25 +51,18 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             @NotNull HttpServletResponse response,
             @NotNull FilterChain filterChain
     ) throws ServletException, IOException {
-        try (ScopedResponseHandled ignored = new ScopedResponseHandled()) {
-            if (!shouldApplyFilter(request, response, filterChain)) {
-                filterChain.doFilter(request, response);
-                return;
-            }
 
-            RateLimitFilterContext context = createContext(request);
-            processRateLimitCheck(context, request, response, filterChain);
+        if (!shouldApplyFilter(request, response, filterChain)) {
+            filterChain.doFilter(request, response);
+            return;
         }
+
+        RateLimitFilterContext context = createContext(request);
+        processRateLimitCheck(context, request, response, filterChain);
     }
 
     /**
      * Rate limit 체크 결과를 처리합니다.
-     * 
-     * @param result Rate limit 체크 결과
-     * @param context Rate Limit 필터 컨텍스트
-     * @param request HTTP 요청
-     * @param response HTTP 응답
-     * @param filterChain 필터 체인
      */
     private void handleRateLimitResult(
             RateLimitResultWithKey result,
@@ -78,6 +71,7 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
+
         if (result.isExceeded()) {
             handleRateLimitExceeded(result, context, request, response);
         } else {
@@ -86,12 +80,7 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     }
 
     /**
-     * Rate limit 초과 시 처리를 수행합니다.
-     * 
-     * @param result Rate limit 체크 결과
-     * @param context Rate Limit 필터 컨텍스트
-     * @param request HTTP 요청
-     * @param response HTTP 응답
+     * Rate limit 초과 시 처리
      */
     private void handleRateLimitExceeded(
             RateLimitResultWithKey result,
@@ -99,7 +88,7 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response
     ) throws IOException {
-        // Rate limit 초과 로깅
+
         logRateLimitExceeded(
                 result.getRule(),
                 result.getKey(),
@@ -108,10 +97,7 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
                 request
         );
 
-        // Rate limit 초과 응답 처리
-        // logCallback은 빈 람다를 전달하여 중복 로깅을 방지합니다.
-        // logCallback은 handle() 메서드 내부에서 recordLog()를 통해 호출되며,
-        // 필요시 추가적인 로깅이나 후처리를 수행할 수 있는 확장 포인트 역할을 합니다.
+        // Exceeded 응답 처리 (중복 로깅 방지를 위해 빈 콜백 전달)
         facade.getExceededFacade().handle(
                 result.getRule(),
                 result.getKey(),
@@ -122,12 +108,7 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     }
 
     /**
-     * Rate limit 체크를 수행하고 결과에 따라 요청을 처리합니다.
-     * 
-     * @param context Rate Limit 필터 컨텍스트
-     * @param request HTTP 요청
-     * @param response HTTP 응답
-     * @param filterChain 필터 체인
+     * Rate limit 체크 메인 흐름
      */
     private void processRateLimitCheck(
             RateLimitFilterContext context,
@@ -135,10 +116,12 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
+
         Optional<RateLimitResultWithKey> result;
         try {
             result = performRateLimitCheck(context, request);
         } catch (Exception e) {
+            // Redis 등 인프라 장애 상황만 정책적으로 처리됨을 전제로 함
             handleRateLimitCheckFailure(e, filterChain, request, response);
             return;
         }
@@ -151,11 +134,7 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     }
 
     /**
-     * Rate limit 체크를 수행합니다.
-     * 
-     * @param context Rate Limit 필터 컨텍스트
-     * @param request HTTP 요청
-     * @return Rate limit 체크 결과 (규칙이 없거나 키를 생성할 수 없는 경우 Optional.empty())
+     * Rate limit 체크 수행
      */
     private Optional<RateLimitResultWithKey> performRateLimitCheck(
             RateLimitFilterContext context,
@@ -177,33 +156,24 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 요청에 대한 Rate limit 규칙을 해석합니다.
-     * 
-     * @param request HTTP 요청
-     * @return Rate limit 규칙 (규칙이 없는 경우 Optional.empty())
+     * 요청에 대한 Rate limit 규칙 해석
      */
     private Optional<RateLimitRule> resolveRule(HttpServletRequest request) {
         return facade.getRuleResolutionService().resolveRule(request);
     }
 
     /**
-     * Rate limit 키를 생성합니다.
-     * 
-     * @param rule Rate limit 규칙
-     * @param context Rate Limit 필터 컨텍스트
-     * @return Rate limit 키 (키를 생성할 수 없는 경우 Optional.empty())
+     * Rate limit 키 생성
      */
-    private Optional<RateLimitKey> buildRateLimitKey(RateLimitRule rule, RateLimitFilterContext context) {
+    private Optional<RateLimitKey> buildRateLimitKey(
+            RateLimitRule rule,
+            RateLimitFilterContext context
+    ) {
         return keyStrategy.buildKey(rule, context);
     }
 
     /**
-     * Rate limit 규칙을 처리하고 결과를 반환합니다.
-     * 
-     * @param rule Rate limit 규칙
-     * @param key Rate limit 키
-     * @param context Rate Limit 필터 컨텍스트
-     * @return Rate limit 체크 결과
+     * Rate limit 규칙 처리
      */
     private Optional<RateLimitResultWithKey> processRateLimitRule(
             RateLimitRule rule,
@@ -211,19 +181,14 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             RateLimitFilterContext context
     ) {
         return facade.getProcessor()
-                .processRule(rule, context, r -> Optional.of(key));
+                .processRule(rule, context, ignored -> Optional.of(key));
     }
 
     /**
-     * Rate limit 체크 실패 시 정책에 따라 요청을 처리합니다.
-     * 
-     * Redis 장애 등으로 Rate Limit 체크가 실패한 경우,
-     * 설정된 Failure Policy에 따라 요청을 허용(Fail-Open)하거나 차단(Fail-Closed)합니다.
-     * 
-     * @param e 발생한 예외
-     * @param filterChain 필터 체인
-     * @param request HTTP 요청
-     * @param response HTTP 응답
+     * Rate limit 체크 실패 시 처리
+     *
+     * Redis 장애 등 인프라 오류 발생 시,
+     * Failure Policy(Fail-Open / Fail-Closed)에 따라 요청을 처리합니다.
      */
     private void handleRateLimitCheckFailure(
             Exception e,
@@ -231,55 +196,50 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response
     ) throws ServletException, IOException {
+
         boolean failOpen = rateLimitProperties.getFailurePolicy().isFailOpen();
         boolean logFailure = rateLimitProperties.getFailurePolicy().isLogFailure();
-        
-        // 규칙 식별 시도 (메트릭 기록용)
+
         Optional<RateLimitRule> ruleOpt = Optional.empty();
         try {
             ruleOpt = resolveRule(request);
-        } catch (Exception resolveException) {
-            // 규칙 해석 실패는 무시 (이미 예외 상황)
+        } catch (Exception ignored) {
+            // 이미 실패 상황이므로 추가 오류는 무시
         }
-        
+
         if (failOpen) {
-            // Fail-Open 정책: 요청 허용
             if (logFailure) {
                 logger.warn(
-                    "Rate limit check failed, allowing request (Fail-Open). " +
-                    "Redis may be down. Request: {}",
-                    request.getRequestURI(),
-                    e
+                        "Rate limit check failed, allowing request (Fail-Open). Request={}",
+                        request.getRequestURI(),
+                        e
                 );
             }
-            
-            // Fail-Open 메트릭 기록
+
             metricsCollector.recordFailOpen(ruleOpt.orElse(null));
-            
             filterChain.doFilter(request, response);
         } else {
-            // Fail-Closed 정책: 요청 차단
             if (logFailure) {
                 logger.error(
-                    "Rate limit check failed, blocking request (Fail-Closed). " +
-                    "Request: {}",
-                    request.getRequestURI(),
-                    e
+                        "Rate limit check failed, blocking request (Fail-Closed). Request={}",
+                        request.getRequestURI(),
+                        e
                 );
             }
-            
+
             sendServiceUnavailableResponse(response);
         }
     }
 
     /**
-     * 서비스 불가 응답을 전송합니다.
-     * 
-     * @param response HTTP 응답
+     * 503 응답 전송
      */
     private void sendServiceUnavailableResponse(HttpServletResponse response) {
         try {
-            response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "Service temporarily unavailable");
+            response.sendError(
+                    HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                    "Service temporarily unavailable"
+            );
         } catch (IOException ioException) {
             logger.error("Failed to send error response", ioException);
             throw new RuntimeException(ioException);
@@ -287,10 +247,13 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 필터 적용 여부 결정
+     * 필터 적용 여부 결정 (확장 포인트)
      */
-    protected boolean shouldApplyFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+    protected boolean shouldApplyFilter(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
         return true;
     }
 
@@ -303,28 +266,4 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             RateLimitFilterContext context,
             HttpServletRequest request
     );
-
-    /**
-     * ThreadLocal 기반 플래그를 Scoped 방식으로 처리
-     */
-    private static final class ScopedResponseHandled implements AutoCloseable {
-        private static final ThreadLocal<Boolean> RESPONSE_HANDLED = ThreadLocal.withInitial(() -> false);
-
-        ScopedResponseHandled() {
-            RESPONSE_HANDLED.set(false);
-        }
-
-        static boolean isHandled() {
-            return RESPONSE_HANDLED.get();
-        }
-
-        static void markHandled() {
-            RESPONSE_HANDLED.set(true);
-        }
-
-        @Override
-        public void close() {
-            RESPONSE_HANDLED.remove();
-        }
-    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/AbstractRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/AbstractRateLimitFilter.java
@@ -8,6 +8,7 @@ import org.example.sharedprompts.auth.rate.RateLimiter;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitFilterContext;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitKey;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitResultWithKey;
+import org.example.sharedprompts.auth.rate.filter.metrics.RateLimitMetricsCollector;
 import org.example.sharedprompts.auth.rate.filter.service.facade.RateLimitFacade;
 import org.example.sharedprompts.auth.rate.filter.strategy.RateLimitKeyStrategy;
 import org.example.sharedprompts.auth.rate.policy.RateLimitProperties;
@@ -30,15 +31,18 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     protected final RateLimitFacade facade;
     protected final RateLimitKeyStrategy keyStrategy;
     protected final RateLimitProperties rateLimitProperties;
+    protected final RateLimitMetricsCollector metricsCollector;
 
     protected AbstractRateLimitFilter(
             RateLimitFacade facade,
             RateLimitKeyStrategy keyStrategy,
-            RateLimitProperties rateLimitProperties
+            RateLimitProperties rateLimitProperties,
+            RateLimitMetricsCollector metricsCollector
     ) {
         this.facade = facade;
         this.keyStrategy = keyStrategy;
         this.rateLimitProperties = rateLimitProperties;
+        this.metricsCollector = metricsCollector;
     }
 
     @Override
@@ -213,6 +217,9 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     /**
      * Rate limit 체크 실패 시 정책에 따라 요청을 처리합니다.
      * 
+     * Redis 장애 등으로 Rate Limit 체크가 실패한 경우,
+     * 설정된 Failure Policy에 따라 요청을 허용(Fail-Open)하거나 차단(Fail-Closed)합니다.
+     * 
      * @param e 발생한 예외
      * @param filterChain 필터 체인
      * @param request HTTP 요청
@@ -225,11 +232,42 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             HttpServletResponse response
     ) throws ServletException, IOException {
         boolean failOpen = rateLimitProperties.getFailurePolicy().isFailOpen();
+        boolean logFailure = rateLimitProperties.getFailurePolicy().isLogFailure();
+        
+        // 규칙 식별 시도 (메트릭 기록용)
+        Optional<RateLimitRule> ruleOpt = Optional.empty();
+        try {
+            ruleOpt = resolveRule(request);
+        } catch (Exception resolveException) {
+            // 규칙 해석 실패는 무시 (이미 예외 상황)
+        }
+        
         if (failOpen) {
-            logger.warn("Rate limit check failed, allowing request (Fail-Open)", e);
+            // Fail-Open 정책: 요청 허용
+            if (logFailure) {
+                logger.warn(
+                    "Rate limit check failed, allowing request (Fail-Open). " +
+                    "Redis may be down. Request: {}",
+                    request.getRequestURI(),
+                    e
+                );
+            }
+            
+            // Fail-Open 메트릭 기록
+            metricsCollector.recordFailOpen(ruleOpt.orElse(null));
+            
             filterChain.doFilter(request, response);
         } else {
-            logger.error("Rate limit check failed, blocking request (Fail-Closed)", e);
+            // Fail-Closed 정책: 요청 차단
+            if (logFailure) {
+                logger.error(
+                    "Rate limit check failed, blocking request (Fail-Closed). " +
+                    "Request: {}",
+                    request.getRequestURI(),
+                    e
+                );
+            }
+            
             sendServiceUnavailableResponse(response);
         }
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/IpRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/IpRateLimitFilter.java
@@ -1,9 +1,6 @@
 package org.example.sharedprompts.auth.rate.filter.impl;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.example.sharedprompts.auth.rate.RateLimiter;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitFilterContext;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitKey;
@@ -14,8 +11,6 @@ import org.example.sharedprompts.auth.rate.policy.RateLimitProperties;
 import org.example.sharedprompts.auth.rate.policy.RateLimitRule;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
 
 /**
  * IP 기반 Rate Limiting 필터
@@ -30,7 +25,7 @@ import java.io.IOException;
  * - 일반 API: 100회/분
  */
 @Component
-@Order(-200)
+@Order(-200) // 인증 필터 이전 실행: IP 기반 제한은 인증 여부와 무관
 public class IpRateLimitFilter extends AbstractRateLimitFilter {
 
     public IpRateLimitFilter(
@@ -40,16 +35,6 @@ public class IpRateLimitFilter extends AbstractRateLimitFilter {
             RateLimitMetricsCollector metricsCollector
     ) {
         super(facade, keyStrategy, rateLimitProperties, metricsCollector);
-    }
-
-    @Override
-    protected boolean shouldApplyFilter(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain
-    ) throws ServletException, IOException {
-        // IP 기반 필터는 인증 여부와 관계없이 모든 요청에 적용
-        return true;
     }
 
     @Override
@@ -65,6 +50,8 @@ public class IpRateLimitFilter extends AbstractRateLimitFilter {
             RateLimitFilterContext context,
             HttpServletRequest request
     ) {
-        facade.getLoggingService().logRateLimitExceeded(rule, key, result, request, null);
+        // IP 기반 Rate Limit은 인증 주체가 없으므로 principal=null
+        facade.getLoggingService()
+                .logRateLimitExceeded(rule, key, result, request, null);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/IpRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/IpRateLimitFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.example.sharedprompts.auth.rate.RateLimiter;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitFilterContext;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitKey;
+import org.example.sharedprompts.auth.rate.filter.metrics.RateLimitMetricsCollector;
 import org.example.sharedprompts.auth.rate.filter.service.facade.RateLimitFacade;
 import org.example.sharedprompts.auth.rate.filter.strategy.IpRateLimitKeyStrategy;
 import org.example.sharedprompts.auth.rate.policy.RateLimitProperties;
@@ -35,9 +36,10 @@ public class IpRateLimitFilter extends AbstractRateLimitFilter {
     public IpRateLimitFilter(
             RateLimitFacade facade,
             IpRateLimitKeyStrategy keyStrategy,
-            RateLimitProperties rateLimitProperties
+            RateLimitProperties rateLimitProperties,
+            RateLimitMetricsCollector metricsCollector
     ) {
-        super(facade, keyStrategy, rateLimitProperties);
+        super(facade, keyStrategy, rateLimitProperties, metricsCollector);
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/UserRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/UserRateLimitFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.example.sharedprompts.auth.rate.RateLimiter;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitFilterContext;
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitKey;
+import org.example.sharedprompts.auth.rate.filter.metrics.RateLimitMetricsCollector;
 import org.example.sharedprompts.auth.rate.filter.service.facade.RateLimitFacade;
 import org.example.sharedprompts.auth.rate.filter.strategy.UserRateLimitKeyStrategy;
 import org.example.sharedprompts.auth.rate.filter.util.auth.AuthenticationHelper;
@@ -36,9 +37,10 @@ public class UserRateLimitFilter extends AbstractRateLimitFilter {
     public UserRateLimitFilter(
             RateLimitFacade facade,
             UserRateLimitKeyStrategy keyStrategy,
-            RateLimitProperties rateLimitProperties
+            RateLimitProperties rateLimitProperties,
+            RateLimitMetricsCollector metricsCollector
     ) {
-        super(facade, keyStrategy, rateLimitProperties);
+        super(facade, keyStrategy, rateLimitProperties, metricsCollector);
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/UserRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/UserRateLimitFilter.java
@@ -31,7 +31,7 @@ import java.util.Optional;
  * - 인증되지 않은 요청은 자동으로 필터를 통과합니다.
  */
 @Component
-@Order(-50)
+@Order(-50) // IP 기반 RateLimit 이후, 인증 필터 이후 실행
 public class UserRateLimitFilter extends AbstractRateLimitFilter {
 
     public UserRateLimitFilter(
@@ -49,15 +49,17 @@ public class UserRateLimitFilter extends AbstractRateLimitFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-        // 인증되지 않은 사용자는 통과 (IP 기반 필터에서 처리)
-        Optional<Long> userIdOpt = AuthenticationHelper.getCurrentUserId();
-        return userIdOpt.isPresent();
+        // 인증되지 않은 요청은 IP 기반 RateLimit에서 처리
+        return AuthenticationHelper.getAuthentication().isPresent();
     }
 
     @Override
     protected RateLimitFilterContext createContext(HttpServletRequest request) {
         Optional<Authentication> authOpt = AuthenticationHelper.getAuthentication();
         Optional<Long> userIdOpt = authOpt.flatMap(AuthenticationHelper::extractUserId);
+
+        // shouldApplyFilter에서 인증 존재를 확인하므로
+        // 실제 처리 경로에서는 userId가 항상 존재하는 것이 정상 케이스
         return RateLimitFilterContext.forUser(
                 request,
                 authOpt.orElse(null),
@@ -74,6 +76,7 @@ public class UserRateLimitFilter extends AbstractRateLimitFilter {
             HttpServletRequest request
     ) {
         Long userId = context.getUserIdOpt().orElse(null);
-        facade.getLoggingService().logRateLimitExceeded(rule, key, result, request, userId);
+        facade.getLoggingService()
+                .logRateLimitExceeded(rule, key, result, request, userId);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsCollector.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsCollector.java
@@ -7,9 +7,12 @@ import org.springframework.stereotype.Component;
 
 /**
  * Rate Limit 메트릭 수집기
- * 
+ *
  * Rate Limit 관련 메트릭을 수집하는 컴포넌트입니다.
- * Observer 패턴을 통해 Rate Limit 체크와 메트릭 수집을 분리합니다.
+ * Observer 패턴을 통해 Rate Limit 체크 로직과 메트릭 수집을 분리합니다.
+ *
+ * 이 클래스는 "무엇이 발생했는지"만 표현하며,
+ * 실패/초과/허용 정책의 의미 해석은 상위 레이어에서 수행합니다.
  */
 @Component
 @RequiredArgsConstructor
@@ -19,8 +22,10 @@ public class RateLimitMetricsCollector {
 
     /**
      * Rate Limit 체크 메트릭을 기록합니다.
-     * 
-     * @param rule RateLimitRule
+     *
+     * 정상적으로 Rate Limit 체크가 수행된 경우에만 호출됩니다.
+     *
+     * @param rule   RateLimitRule
      * @param result RateLimitResult
      */
     public void recordCheck(RateLimitRule rule, RateLimiter.RateLimitResult result) {
@@ -33,10 +38,10 @@ public class RateLimitMetricsCollector {
 
     /**
      * Rate Limit 초과 메트릭을 기록합니다.
-     * 
-     * @param rule RateLimitRule
+     *
+     * @param rule         RateLimitRule
      * @param currentCount 현재 카운트
-     * @param limit 제한 값
+     * @param limit        제한 값
      */
     public void recordExceeded(RateLimitRule rule, long currentCount, long limit) {
         metricsService.recordRateLimitExceeded(rule, currentCount, limit);
@@ -44,8 +49,11 @@ public class RateLimitMetricsCollector {
 
     /**
      * Rate Limit 체크 실패 메트릭을 기록합니다.
-     * 
-     * @param rule RateLimitRule
+     *
+     * Redis 장애, 내부 오류 등으로 Rate Limit 체크 자체가
+     * 정상 수행되지 못한 경우를 의미합니다.
+     *
+     * @param rule RateLimitRule (null 가능 - 규칙을 식별할 수 없는 경우)
      */
     public void recordFailed(RateLimitRule rule) {
         metricsService.recordRateLimitCheckFailed(rule);
@@ -53,14 +61,13 @@ public class RateLimitMetricsCollector {
 
     /**
      * Rate Limit Fail-Open 메트릭을 기록합니다.
-     * 
-     * Redis 장애 등으로 Rate Limit 체크가 실패했을 때
-     * Fail-Open 정책에 의해 요청이 허용된 경우를 기록합니다.
-     * 
+     *
+     * Redis 장애 등으로 Rate Limit 체크가 실패했지만
+     * Fail-Open 정책에 따라 요청이 허용된 경우를 기록합니다.
+     *
      * @param rule RateLimitRule (null 가능 - 규칙을 식별할 수 없는 경우)
      */
     public void recordFailOpen(RateLimitRule rule) {
         metricsService.recordRateLimitFailOpen(rule);
     }
 }
-

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsCollector.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsCollector.java
@@ -50,5 +50,17 @@ public class RateLimitMetricsCollector {
     public void recordFailed(RateLimitRule rule) {
         metricsService.recordRateLimitCheckFailed(rule);
     }
+
+    /**
+     * Rate Limit Fail-Open 메트릭을 기록합니다.
+     * 
+     * Redis 장애 등으로 Rate Limit 체크가 실패했을 때
+     * Fail-Open 정책에 의해 요청이 허용된 경우를 기록합니다.
+     * 
+     * @param rule RateLimitRule (null 가능 - 규칙을 식별할 수 없는 경우)
+     */
+    public void recordFailOpen(RateLimitRule rule) {
+        metricsService.recordRateLimitFailOpen(rule);
+    }
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsService.java
@@ -19,6 +19,7 @@ public class RateLimitMetricsService {
     private static final String RATE_LIMIT_CHECK = "rate.limit.check";
     private static final String RATE_LIMIT_EXCEEDED = "rate.limit.exceeded";
     private static final String RATE_LIMIT_CHECK_FAILED = "rate.limit.check.failed";
+    private static final String RATE_LIMIT_FAIL_OPEN = "rate.limit.fail.open";
 
     private final MeterRegistry meterRegistry;
 
@@ -61,5 +62,26 @@ public class RateLimitMetricsService {
                 .tag("rule", rule.getName())
                 .register(meterRegistry)
                 .increment();
+    }
+
+    /**
+     * Rate Limit Fail-Open 메트릭을 기록합니다.
+     * 
+     * Redis 장애 등으로 Rate Limit 체크가 실패했을 때
+     * Fail-Open 정책에 의해 요청이 허용된 경우를 기록합니다.
+     * 
+     * @param rule RateLimitRule (null 가능 - 규칙을 식별할 수 없는 경우)
+     */
+    public void recordRateLimitFailOpen(RateLimitRule rule) {
+        Counter.Builder builder = Counter.builder(RATE_LIMIT_FAIL_OPEN)
+                .description("Rate Limit 체크 실패 시 Fail-Open 정책으로 요청이 허용된 횟수");
+        
+        if (rule != null) {
+            builder.tag("rule", rule.getName());
+        } else {
+            builder.tag("rule", "unknown");
+        }
+        
+        builder.register(meterRegistry).increment();
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/metrics/RateLimitMetricsService.java
@@ -1,6 +1,5 @@
 package org.example.sharedprompts.auth.rate.filter.metrics;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import org.example.sharedprompts.auth.rate.RateLimiter;
@@ -9,8 +8,12 @@ import org.springframework.stereotype.Service;
 
 /**
  * Rate Limit 메트릭 서비스
- * 
+ *
  * Rate Limit 관련 메트릭을 Micrometer를 통해 수집합니다.
+ *
+ * ⚠️ 주의:
+ * - Meter는 (name + tags) 조합 기준으로 캐시되므로
+ *   매 요청마다 Counter.builder().register()를 호출하지 않습니다.
  */
 @Service
 @RequiredArgsConstructor
@@ -24,64 +27,58 @@ public class RateLimitMetricsService {
     private final MeterRegistry meterRegistry;
 
     /**
-     * Rate Limit 체크 메트릭을 기록합니다.
-     * 
-     * @param rule RateLimitRule
-     * @param result RateLimitResult
-     * @param isExceeded 초과 여부
+     * Rate Limit 체크 메트릭 기록
      */
-    public void recordRateLimitCheck(RateLimitRule rule, RateLimiter.RateLimitResult result, boolean isExceeded) {
-        Counter.builder(RATE_LIMIT_CHECK)
-                .tag("rule", rule.getName())
-                .tag("exceeded", String.valueOf(isExceeded))
-                .register(meterRegistry)
-                .increment();
+    public void recordRateLimitCheck(
+            RateLimitRule rule,
+            RateLimiter.RateLimitResult result,
+            boolean isExceeded
+    ) {
+        meterRegistry.counter(
+                RATE_LIMIT_CHECK,
+                "rule", safeRuleName(rule),
+                "exceeded", String.valueOf(isExceeded)
+        ).increment();
     }
 
     /**
-     * Rate Limit 초과 메트릭을 기록합니다.
-     * 
-     * @param rule RateLimitRule
-     * @param currentCount 현재 카운트
-     * @param limit 제한 값
+     * Rate Limit 초과 메트릭 기록
      */
-    public void recordRateLimitExceeded(RateLimitRule rule, long currentCount, long limit) {
-        Counter.builder(RATE_LIMIT_EXCEEDED)
-                .tag("rule", rule.getName())
-                .register(meterRegistry)
-                .increment();
+    public void recordRateLimitExceeded(
+            RateLimitRule rule,
+            long currentCount,
+            long limit
+    ) {
+        meterRegistry.counter(
+                RATE_LIMIT_EXCEEDED,
+                "rule", safeRuleName(rule)
+        ).increment();
     }
 
     /**
-     * Rate Limit 체크 실패 메트릭을 기록합니다.
-     * 
-     * @param rule RateLimitRule
+     * Rate Limit 체크 실패 메트릭 기록
      */
     public void recordRateLimitCheckFailed(RateLimitRule rule) {
-        Counter.builder(RATE_LIMIT_CHECK_FAILED)
-                .tag("rule", rule.getName())
-                .register(meterRegistry)
-                .increment();
+        meterRegistry.counter(
+                RATE_LIMIT_CHECK_FAILED,
+                "rule", safeRuleName(rule)
+        ).increment();
     }
 
     /**
-     * Rate Limit Fail-Open 메트릭을 기록합니다.
-     * 
-     * Redis 장애 등으로 Rate Limit 체크가 실패했을 때
-     * Fail-Open 정책에 의해 요청이 허용된 경우를 기록합니다.
-     * 
-     * @param rule RateLimitRule (null 가능 - 규칙을 식별할 수 없는 경우)
+     * Rate Limit Fail-Open 메트릭 기록
      */
     public void recordRateLimitFailOpen(RateLimitRule rule) {
-        Counter.Builder builder = Counter.builder(RATE_LIMIT_FAIL_OPEN)
-                .description("Rate Limit 체크 실패 시 Fail-Open 정책으로 요청이 허용된 횟수");
-        
-        if (rule != null) {
-            builder.tag("rule", rule.getName());
-        } else {
-            builder.tag("rule", "unknown");
-        }
-        
-        builder.register(meterRegistry).increment();
+        meterRegistry.counter(
+                RATE_LIMIT_FAIL_OPEN,
+                "rule", safeRuleName(rule)
+        ).increment();
+    }
+
+    /**
+     * rule 이름 null-safe 처리
+     */
+    private String safeRuleName(RateLimitRule rule) {
+        return rule != null ? rule.getName() : "unknown";
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/policy/RateLimitFailurePolicy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/policy/RateLimitFailurePolicy.java
@@ -25,5 +25,18 @@ public class RateLimitFailurePolicy {
      *   별도의 Circuit Breaker 패턴과 함께 사용하는 것을 권장합니다.
      */
     private boolean failOpen = true;
+
+    /**
+     * 장애 로깅 활성화 여부
+     * 
+     * true: Rate limit 체크 실패 시 상세 로깅 수행
+     * false: Rate limit 체크 실패 시 최소 로깅만 수행
+     * 
+     * 기본값: true
+     * 
+     * 로깅 내용:
+     * - 요청 URI, 예외 정보, Fail-Open/Fail-Closed 정책 적용 여부 등
+     */
+    private boolean logFailure = true;
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/security/config/constants/SecurityPathConstants.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/security/config/constants/SecurityPathConstants.java
@@ -42,6 +42,10 @@ public final class SecurityPathConstants {
             "/auth/login",
             "/auth/callback",
             "/auth/refresh",
+            "/api/auth/signup",
+            "/api/auth/login",
+            "/api/auth/callback",
+            "/api/auth/refresh",
             "/oauth2/**",
             "/login/**"
     };

--- a/sharedPrompts/src/main/resources/application.yml
+++ b/sharedPrompts/src/main/resources/application.yml
@@ -264,6 +264,14 @@ rate-limit:
     cleanup:
       enabled: ${RATE_LIMIT_LOG_CLEANUP_ENABLED:true}
       retention-days: ${RATE_LIMIT_LOG_CLEANUP_RETENTION_DAYS:90}
+  failure-policy:
+    # Redis 장애 시 Rate Limit 체크 실패 정책
+    # true: Fail-Open (요청 허용, 가용성 우선) - 기본값
+    # false: Fail-Closed (요청 차단, 보안 우선)
+    fail-open: ${RATE_LIMIT_FAILURE_POLICY_FAIL_OPEN:true}
+    # 장애 로깅 활성화 여부
+    # true: Redis 장애 시 상세 로깅 수행
+    log-failure: ${RATE_LIMIT_FAILURE_POLICY_LOG_FAILURE:true}
 
 # =========================
 # 애플리케이션 설정


### PR DESCRIPTION
- Fail-Open/Fail-Closed 정책 명시적 설정 추가
- Redis 장애 시 로깅 및 메트릭 기록 개선
- application.yml에 failure-policy 설정 추가
- AbstractRateLimitFilter의 handleRateLimitCheckFailure 메서드 개선
- RateLimitMetricsCollector, RateLimitMetricsService 개선

관련 이슈: 전체_코드베이스_개선_리뷰.md #2