### PR TITLE
Add validation to PromptSearchCondition DTO and update PromptControll…

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/controller/prompt/PromptController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/controller/prompt/PromptController.java
@@ -35,7 +35,7 @@ public class PromptController {
 
     @GetMapping
     public ResponseEntity<CustomResponse<PageResponse<PromptResponseDto>>> getPrompts(
-            @ModelAttribute("condition") PromptSearchCondition condition,
+            @Valid @ModelAttribute("condition") PromptSearchCondition condition,
             @CurrentUser AuthUser authUser
     ) {
         Long viewerId = authUser != null ? authUser.getId() : null;
@@ -73,7 +73,7 @@ public class PromptController {
     @GetMapping("/me")
     public ResponseEntity<CustomResponse<PageResponse<PromptResponseDto>>> getMyPrompts(
             @CurrentUser AuthUser authUser,
-            @ModelAttribute("condition") PromptSearchCondition condition
+            @Valid @ModelAttribute("condition") PromptSearchCondition condition
     ) {
         PageResponse<PromptResponseDto> response = promptService.getMyPrompts(authUser.getId(), condition);
         return CustomResponseHelper.ok(response);
@@ -85,7 +85,7 @@ public class PromptController {
     @GetMapping("/user/{userId}")
     public ResponseEntity<CustomResponse<PageResponse<PromptResponseDto>>> getUserPrompts(
             @PathVariable Long userId,
-            @ModelAttribute("condition") PromptSearchCondition condition,
+            @Valid @ModelAttribute("condition") PromptSearchCondition condition,
             @CurrentUser AuthUser authUser
     ) {
         Long viewerId = authUser != null ? authUser.getId() : null;

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/prompt/request/PromptSearchCondition.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/prompt/request/PromptSearchCondition.java
@@ -1,6 +1,8 @@
 package org.example.sharedprompts.dto.prompt.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,7 +14,11 @@ import org.example.sharedprompts.domain.prompt.enums.SortType;
 @NoArgsConstructor
 public class PromptSearchCondition {
 
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
     private int page = 0;
+
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+    @Max(value = 100, message = "페이지 크기는 100 이하로 입력해주세요.")
     private int size = 20;
     private SortType sort = SortType.LATEST;
 


### PR DESCRIPTION
…er for enhanced security

- Added validation to `PromptSearchCondition` DTO:
  - `page`: @Min(value = 0) to prevent negative values
  - `size`: @Min(value = 1), @Max(value = 100) to restrict size within 1-100 (matches `max-page-size` in application.yml)

- Applied @Valid annotation to `getPrompts()`, `getMyPrompts()`, and `getUserPrompts()` methods in `PromptController`.

- Security improvement:
  - Prevented potential DoS risk by limiting `size` to 1-100 and `page` to 0 or greater.

- Error messages for invalid input:
  - `size=0` or `size=-1`: "페이지 크기는 1 이상이어야 합니다."
  - `size=101` or `size=10000`: "페이지 크기는 100 이하로 입력해주세요."
  - `page=-1`: "페이지 번호는 0 이상이어야 합니다."

- Enhanced performance and security by enforcing size limits on all pagination endpoints.