### PR TITLE
fix: 프롬프트 생성/삭제 시 개인 통계 캐시 무효화 추가

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/SharedPromptsApplication.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/SharedPromptsApplication.java
@@ -1,14 +1,17 @@
 package org.example.sharedprompts;
 
+import org.example.sharedprompts.global.config.PromptCreationProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
 @EnableAsync
 @ConfigurationPropertiesScan  // 전체 패키지 스캔 (환경별 설정 적용을 위해)
+@EnableConfigurationProperties(PromptCreationProperties.class)
 @SpringBootApplication
 public class SharedPromptsApplication {
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/FixedWindowRateLimiter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/FixedWindowRateLimiter.java
@@ -1,7 +1,7 @@
 package org.example.sharedprompts.auth.rate;
 
 import lombok.RequiredArgsConstructor;
-import org.example.sharedprompts.global.Lua.LuaScripts;
+import org.example.sharedprompts.global.lua.LuaScripts;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/security/config/constants/SecurityPathConstants.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/security/config/constants/SecurityPathConstants.java
@@ -31,6 +31,7 @@ public final class SecurityPathConstants {
      *   <li>OAuth2 콜백: /auth/callback</li>
      *   <li>토큰 갱신: /auth/refresh</li>
      *   <li>OAuth2 로그인: /oauth2/**, /login/**</li>
+     *   <li>Actuator Health: /actuator/health (헬스 체크용)</li>
      * </ul>
      *
      * <p><strong>주의:</strong> context-path({@code /api})는 포함하지 않습니다.
@@ -47,7 +48,8 @@ public final class SecurityPathConstants {
             "/api/auth/callback",
             "/api/auth/refresh",
             "/oauth2/**",
-            "/login/**"
+            "/login/**",
+            "/actuator/health"  // 헬스 체크는 공개 접근 허용
     };
 
     /**
@@ -62,7 +64,10 @@ public final class SecurityPathConstants {
      * 반드시 servlet path인 {@code /admin/**}만 사용해야 합니다.
      */
     public static final String[] ADMIN_PATHS = {
-            "/admin/**"
+            "/admin/**",
+            "/actuator/info",      // Actuator info 엔드포인트 (관리자 전용)
+            "/actuator/metrics",   // Actuator metrics 엔드포인트 (관리자 전용)
+            "/actuator/prometheus" // Actuator prometheus 엔드포인트 (관리자 전용)
     };
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/facade/PromptFacade.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/facade/PromptFacade.java
@@ -6,6 +6,7 @@ import org.example.sharedprompts.dto.common.CustomResponse;
 import org.example.sharedprompts.dto.common.CustomResponseHelper;
 import org.example.sharedprompts.dto.prompt.request.PromptRequestDto;
 import org.example.sharedprompts.dto.prompt.response.PromptResponseDto;
+import org.example.sharedprompts.global.config.PromptCreationProperties;
 import org.example.sharedprompts.global.exception.ApiException;
 import org.example.sharedprompts.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -27,10 +28,8 @@ import java.util.concurrent.TimeoutException;
 @RequiredArgsConstructor
 public class PromptFacade {
 
-    private static final long TIMEOUT_MS = 40_000L;
-    private static final long FUTURE_TIMEOUT_MS = TIMEOUT_MS - 1_000L;
-
     private final PromptCreationFlow promptCreationFlow;
+    private final PromptCreationProperties promptCreationProperties;
 
     @Qualifier("aiCallTaskExecutorWithSecurityContext")
     private final ExecutorService aiCallTaskExecutorWithSecurityContext;
@@ -40,6 +39,9 @@ public class PromptFacade {
             Long userId
     ) {
 
+        long timeoutMs = promptCreationProperties.getTimeoutMs();
+        long futureTimeoutMs = promptCreationProperties.getFutureTimeoutMs();
+        
         Callable<ResponseEntity<CustomResponse<PromptResponseDto>>> callable = () -> {
             try {
                 log.debug("프롬프트 생성 시작: userId={}, title={}", userId, request.getTitle());
@@ -48,7 +50,7 @@ public class PromptFacade {
                         () -> promptCreationFlow.create(request, userId)
                 );
 
-                PromptResponseDto result = future.get(FUTURE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                PromptResponseDto result = future.get(futureTimeoutMs, TimeUnit.MILLISECONDS);
 
                 log.info("프롬프트 생성 완료: userId={}, promptId={}", userId, result.getId());
                 
@@ -68,7 +70,7 @@ public class PromptFacade {
                 return createFailResponse(e);
 
             } catch (TimeoutException e) {
-                log.warn("프롬프트 생성 Future 타임아웃: userId={}, timeout={}ms", userId, FUTURE_TIMEOUT_MS, e);
+                log.warn("프롬프트 생성 Future 타임아웃: userId={}, timeout={}ms", userId, futureTimeoutMs, e);
                 return createFailResponse(new ApiException(
                         ErrorCode.AI_GENERATION_FAILED,
                         "프롬프트 생성이 시간 초과되었습니다. 잠시 후 다시 시도해주세요."
@@ -95,10 +97,10 @@ public class PromptFacade {
         };
 
         WebAsyncTask<ResponseEntity<CustomResponse<PromptResponseDto>>> asyncTask =
-                new WebAsyncTask<>(TIMEOUT_MS, callable);
+                new WebAsyncTask<>(timeoutMs, callable);
 
         asyncTask.onTimeout(() -> {
-            log.warn("프롬프트 생성 WebAsyncTask 타임아웃: userId={}, timeout={}ms", userId, TIMEOUT_MS);
+            log.warn("프롬프트 생성 WebAsyncTask 타임아웃: userId={}, timeout={}ms", userId, timeoutMs);
             return createFailResponse(new ApiException(
                     ErrorCode.AI_GENERATION_FAILED,
                     "프롬프트 생성이 시간 초과되었습니다. 잠시 후 다시 시도해주세요."

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/service/PromptPersistenceService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/service/PromptPersistenceService.java
@@ -31,6 +31,14 @@ public class PromptPersistenceService {
 
     /**
      * 프롬프트 저장과 태그 처리, 트랜잭션 관리를 담당한다.
+     * 
+     * <p><strong>트랜잭션 전파 전략:</strong>
+     * {@code REQUIRES_NEW}를 사용하여 외부 트랜잭션과 독립적으로 동작합니다.
+     * 이는 프롬프트 저장이 실패해도 외부 트랜잭션이 롤백되지 않도록 하기 위함입니다.
+     * 
+     * <p><strong>주의:</strong> 이로 인해 데이터 일관성 문제가 발생할 수 있습니다.
+     * 프롬프트 저장이 실패해도 외부 트랜잭션이 커밋될 수 있으므로,
+     * 비즈니스 요구사항에 따라 전파 전략을 재검토해야 할 수 있습니다.
      */
     @Transactional(propagation=REQUIRES_NEW, timeout=30)
     public PromptResponseDto savePrompt(PromptRequestDto request, Long userId, String aiGeneratedContent) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/tag/count/TagCountUpdateService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/tag/count/TagCountUpdateService.java
@@ -3,7 +3,7 @@ package org.example.sharedprompts.domain.tag.count;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.domain.tag.config.TagRedisKey;
-import org.example.sharedprompts.global.Lua.LuaScripts;
+import org.example.sharedprompts.global.lua.LuaScripts;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/EnvironmentValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/EnvironmentValidator.java
@@ -1,10 +1,10 @@
 package org.example.sharedprompts.global.config;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.ApplicationListener;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,29 +14,34 @@ import java.util.List;
  * 
  * <p>프로덕션 환경에서 필수 환경 변수가 누락되거나 잘못된 프로필이 설정된 경우
  * 애플리케이션 시작을 중단합니다.
+ * 
+ * <p>EnvironmentPostProcessor를 사용하여 빈 생성 전에 검증을 수행합니다.
+ * 이를 통해 리소스(데이터베이스 연결, 포트 바인딩 등)가 할당되기 전에 
+ * 필수 환경 변수를 검증할 수 있습니다.
+ * 
+ * <p>이 클래스는 META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor 파일에
+ * 등록되어야 합니다.
  */
 @Slf4j
-@Component
-public class EnvironmentValidator implements ApplicationListener<ApplicationReadyEvent> {
+public class EnvironmentValidator implements EnvironmentPostProcessor {
 
     private static final String PROD_PROFILE = "prod";
     private static final String DEV_PROFILE = "dev";
 
     @Override
-    public void onApplicationEvent(ApplicationReadyEvent event) {
-        Environment env = event.getApplicationContext().getEnvironment();
-        String[] activeProfiles = env.getActiveProfiles();
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        String[] activeProfiles = environment.getActiveProfiles();
         
         log.info("Active profiles: {}", String.join(", ", activeProfiles.length > 0 ? activeProfiles : new String[]{"default"}));
         
         // 프로필 검증
-        validateProfile(env, activeProfiles);
+        validateProfile(environment, activeProfiles);
         
         // 환경 변수 검증
-        validateEnvironmentVariables(env, activeProfiles);
+        validateEnvironmentVariables(environment, activeProfiles);
         
         // 설정 검증 (JPA DDL, 로깅 레벨 등)
-        validateConfiguration(env, activeProfiles);
+        validateConfiguration(environment, activeProfiles);
         
         log.info("✅ 환경 변수 및 프로필 검증 완료");
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/EnvironmentValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/EnvironmentValidator.java
@@ -1,0 +1,223 @@
+package org.example.sharedprompts.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 애플리케이션 시작 시 환경 변수 및 프로필 검증
+ * 
+ * <p>프로덕션 환경에서 필수 환경 변수가 누락되거나 잘못된 프로필이 설정된 경우
+ * 애플리케이션 시작을 중단합니다.
+ */
+@Slf4j
+@Component
+public class EnvironmentValidator implements ApplicationListener<ApplicationReadyEvent> {
+
+    private static final String PROD_PROFILE = "prod";
+    private static final String DEV_PROFILE = "dev";
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        Environment env = event.getApplicationContext().getEnvironment();
+        String[] activeProfiles = env.getActiveProfiles();
+        
+        log.info("Active profiles: {}", String.join(", ", activeProfiles.length > 0 ? activeProfiles : new String[]{"default"}));
+        
+        // 프로필 검증
+        validateProfile(env, activeProfiles);
+        
+        // 환경 변수 검증
+        validateEnvironmentVariables(env, activeProfiles);
+        
+        // 설정 검증 (JPA DDL, 로깅 레벨 등)
+        validateConfiguration(env, activeProfiles);
+        
+        log.info("✅ 환경 변수 및 프로필 검증 완료");
+    }
+
+    /**
+     * 프로필 검증
+     * 프로덕션 환경에서는 반드시 'prod' 프로필이 활성화되어야 합니다.
+     */
+    private void validateProfile(Environment env, String[] activeProfiles) {
+        boolean isProdProfile = containsProfile(activeProfiles, PROD_PROFILE);
+        boolean isDevProfile = containsProfile(activeProfiles, DEV_PROFILE);
+        
+        // 프로덕션 환경 감지 (환경 변수 또는 시스템 속성으로 판단)
+        String deploymentEnv = env.getProperty("DEPLOYMENT_ENV", String.class);
+        boolean isProductionEnvironment = "production".equalsIgnoreCase(deploymentEnv) 
+                || "prod".equalsIgnoreCase(deploymentEnv)
+                || System.getProperty("deployment.env", "").equalsIgnoreCase("production");
+        
+        if (isProductionEnvironment && !isProdProfile) {
+            String errorMessage = String.format(
+                "❌ 프로덕션 환경에서는 반드시 'prod' 프로필이 활성화되어야 합니다. " +
+                "현재 활성 프로필: %s. " +
+                "환경 변수 SPRING_PROFILES_ACTIVE=prod를 설정하세요.",
+                String.join(", ", activeProfiles.length > 0 ? activeProfiles : new String[]{"default"})
+            );
+            log.error(errorMessage);
+            throw new IllegalStateException(errorMessage);
+        }
+        
+        // 개발 환경에서 prod 프로필이 활성화된 경우 경고
+        if (isDevProfile && isProdProfile) {
+            log.warn("⚠️ 개발 프로필과 프로덕션 프로필이 동시에 활성화되었습니다. 개발 환경에서는 'dev' 프로필만 사용하는 것을 권장합니다.");
+        }
+    }
+
+    /**
+     * 환경 변수 검증
+     * 필수 환경 변수가 누락되었는지 확인합니다.
+     */
+    private void validateEnvironmentVariables(Environment env, String[] activeProfiles) {
+        boolean isProdProfile = containsProfile(activeProfiles, PROD_PROFILE);
+        List<String> missingVariables = new ArrayList<>();
+        
+        // 공통 필수 환경 변수
+        List<String> requiredVariables = new ArrayList<>(List.of(
+            "JWT_SECRET",
+            "SPRING_DATASOURCE_URL",
+            "SPRING_DATASOURCE_USERNAME",
+            "SPRING_DATASOURCE_PASSWORD",
+            "CORS_ALLOWED_ORIGINS",
+            "OAUTH2_REDIRECT_FRONT_URL",
+            "OAUTH2_FAILURE_REDIRECT_URL",
+            "OAUTH2_SALT"
+        ));
+        
+        // OAuth2 클라이언트 정보
+        requiredVariables.addAll(List.of(
+            "GOOGLE_CLIENT_ID",
+            "GOOGLE_CLIENT_SECRET",
+            "NAVER_CLIENT_ID",
+            "NAVER_CLIENT_SECRET",
+            "KAKAO_CLIENT_ID",
+            "KAKAO_CLIENT_SECRET"
+        ));
+        
+        // 프로덕션 환경에서만 필수인 변수들
+        if (isProdProfile) {
+            requiredVariables.addAll(List.of(
+                "GOOGLE_GEMINI_API_KEY",
+                "SPRING_AI_OPENAI_API_KEY"
+            ));
+        }
+        
+        // 환경 변수 검증
+        for (String varName : requiredVariables) {
+            String value = env.getProperty(varName);
+            if (value == null || value.trim().isEmpty()) {
+                missingVariables.add(varName);
+            }
+        }
+        
+        // 더미 API 키 검증 (프로덕션 환경)
+        if (isProdProfile) {
+            String openaiApiKey = env.getProperty("SPRING_AI_OPENAI_API_KEY");
+            if (openaiApiKey != null && openaiApiKey.equals("dummy-openai-api-key")) {
+                log.error("❌ 프로덕션 환경에서 더미 OpenAI API 키가 사용되고 있습니다. 실제 API 키를 설정하세요.");
+                throw new IllegalStateException("프로덕션 환경에서는 실제 OpenAI API 키가 필요합니다.");
+            }
+        }
+        
+        // 누락된 환경 변수 보고
+        if (!missingVariables.isEmpty()) {
+            String errorMessage = String.format(
+                "❌ 필수 환경 변수가 누락되었습니다: %s\n" +
+                "배포 전 체크리스트를 확인하고 모든 필수 환경 변수를 설정하세요.",
+                String.join(", ", missingVariables)
+            );
+            log.error(errorMessage);
+            throw new IllegalStateException(errorMessage);
+        }
+        
+        // 프로덕션 환경에서 localhost 사용 경고
+        if (isProdProfile) {
+            String redisHost = env.getProperty("REDIS_HOST", "localhost");
+            String rabbitmqHost = env.getProperty("RABBITMQ_HOST", "localhost");
+            
+            if ("localhost".equals(redisHost) || "127.0.0.1".equals(redisHost)) {
+                log.warn("⚠️ 프로덕션 환경에서 Redis 호스트가 localhost로 설정되어 있습니다. 실제 Redis 서버 주소를 설정하세요.");
+            }
+            
+            if ("localhost".equals(rabbitmqHost) || "127.0.0.1".equals(rabbitmqHost)) {
+                log.warn("⚠️ 프로덕션 환경에서 RabbitMQ 호스트가 localhost로 설정되어 있습니다. 실제 RabbitMQ 서버 주소를 설정하세요.");
+            }
+            
+            // RabbitMQ 기본 자격 증명 경고
+            String rabbitmqUsername = env.getProperty("RABBITMQ_USERNAME", "guest");
+            String rabbitmqPassword = env.getProperty("RABBITMQ_PASSWORD", "guest");
+            
+            if ("guest".equals(rabbitmqUsername) && "guest".equals(rabbitmqPassword)) {
+                log.warn("⚠️ 프로덕션 환경에서 RabbitMQ 기본 자격 증명(guest/guest)이 사용되고 있습니다. 강력한 자격 증명으로 변경하세요.");
+            }
+        }
+    }
+
+    /**
+     * 설정 검증
+     * 프로덕션 환경에서 위험한 설정이 사용되고 있는지 확인합니다.
+     */
+    private void validateConfiguration(Environment env, String[] activeProfiles) {
+        boolean isProdProfile = containsProfile(activeProfiles, PROD_PROFILE);
+        
+        if (!isProdProfile) {
+            return; // 프로덕션 환경이 아니면 검증 스킵
+        }
+        
+        // JPA DDL Auto 설정 검증 (프로덕션에서 update 사용 시 위험)
+        String ddlAuto = env.getProperty("spring.jpa.hibernate.ddl-auto", 
+                env.getProperty("JPA_DDL_AUTO", "none"));
+        if ("update".equalsIgnoreCase(ddlAuto) || "create".equalsIgnoreCase(ddlAuto) 
+                || "create-drop".equalsIgnoreCase(ddlAuto)) {
+            String errorMessage = String.format(
+                "❌ 프로덕션 환경에서 위험한 JPA DDL 설정이 감지되었습니다: %s. " +
+                "프로덕션 환경에서는 반드시 'none'으로 설정해야 합니다. " +
+                "스키마 변경은 마이그레이션 도구(Flyway, Liquibase)를 사용하세요.",
+                ddlAuto
+            );
+            log.error(errorMessage);
+            throw new IllegalStateException(errorMessage);
+        }
+        
+        // 로깅 레벨 검증 (프로덕션에서 DEBUG 사용 시 경고)
+        String rootLogLevel = env.getProperty("logging.level.root", "INFO");
+        if ("DEBUG".equalsIgnoreCase(rootLogLevel) || "TRACE".equalsIgnoreCase(rootLogLevel)) {
+            log.warn("⚠️ 프로덕션 환경에서 DEBUG/TRACE 로깅 레벨이 설정되어 있습니다. " +
+                    "성능 및 보안을 위해 INFO 레벨 이상을 권장합니다.");
+        }
+        
+        // 커넥션 풀 크기 경고 (기본값 사용 시)
+        String maxPoolSize = env.getProperty("HIKARI_MAXIMUM_POOL_SIZE");
+        if (maxPoolSize == null || maxPoolSize.trim().isEmpty()) {
+            log.warn("⚠️ 프로덕션 환경에서 HikariCP 커넥션 풀 크기가 기본값으로 설정되어 있습니다. " +
+                    "실제 트래픽에 맞게 HIKARI_MAXIMUM_POOL_SIZE를 조정하는 것을 권장합니다.");
+        }
+        
+        // OAuth2 리다이렉트 URL 형식 검증
+        String oauth2RedirectUrl = env.getProperty("OAUTH2_REDIRECT_FRONT_URL");
+        if (oauth2RedirectUrl != null && !oauth2RedirectUrl.trim().isEmpty()) {
+            if (!oauth2RedirectUrl.startsWith("http://") && !oauth2RedirectUrl.startsWith("https://")) {
+                log.warn("⚠️ OAuth2 리다이렉트 URL이 올바른 형식이 아닐 수 있습니다: {}. " +
+                        "실제 OAuth 제공자에 등록된 URL과 일치하는지 확인하세요.", oauth2RedirectUrl);
+            }
+        }
+    }
+
+    private boolean containsProfile(String[] profiles, String profile) {
+        for (String p : profiles) {
+            if (p.equals(profile)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
@@ -1,0 +1,30 @@
+package org.example.sharedprompts.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 프롬프트 생성 관련 설정 속성
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.prompt.creation")
+public class PromptCreationProperties {
+    /**
+     * 프롬프트 생성 타임아웃 (밀리초)
+     * 기본값: 40000ms (40초)
+     */
+    private long timeoutMs = 40_000L;
+
+    /**
+     * Future 타임아웃 (밀리초)
+     * WebAsyncTask 타임아웃보다 1초 짧게 설정
+     */
+    public long getFutureTimeoutMs() {
+        return timeoutMs - 1_000L;
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
@@ -2,21 +2,20 @@ package org.example.sharedprompts.global.config;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+
+import javax.validation.constraints.Min;
 
 /**
  * 프롬프트 생성 관련 설정 속성
  */
 @Getter
 @Setter
-@Component
-@ConfigurationProperties(prefix = "app.prompt.creation")
 public class PromptCreationProperties {
     /**
      * 프롬프트 생성 타임아웃 (밀리초)
      * 기본값: 40000ms (40초)
      */
+    @Min(2000) // Ensure that timeoutMs is at least 2000ms
     private long timeoutMs = 40_000L;
 
     /**
@@ -27,4 +26,3 @@ public class PromptCreationProperties {
         return timeoutMs - 1_000L;
     }
 }
-

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/redis/RedisLuaScriptConfig.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/redis/RedisLuaScriptConfig.java
@@ -1,6 +1,6 @@
 package org.example.sharedprompts.global.config.redis;
 
-import org.example.sharedprompts.global.Lua.LuaScripts;
+import org.example.sharedprompts.global.lua.LuaScripts;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.script.DefaultRedisScript;

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/lua/LuaScripts.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/lua/LuaScripts.java
@@ -1,0 +1,284 @@
+package org.example.sharedprompts.global.lua;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LuaScripts {
+
+    public static final String SAFE_DECREMENT = """
+        local val = redis.call('GET', KEYS[1])
+        if not val then
+            return 0
+        end
+        
+        local num = tonumber(val)
+        if not num then
+            return 0
+        end
+
+        if num <= 0 then
+            return 0
+        end
+
+        return redis.call('DECR', KEYS[1])
+        """;
+
+    /**
+     * INCR + EXPIRE 를 하나의 Lua 스크립트에서 처리하여
+     * TTL 설정까지 원자적으로 보장하기 위한 스크립트입니다.
+     *
+     * KEYS[1] : 대상 key
+     * ARGV[1] : TTL (seconds)
+     */
+    public static final String INCREMENT_WITH_TTL = """
+        local key = KEYS[1]
+        local ttl = tonumber(ARGV[1])
+
+        local newVal = redis.call('INCR', key)
+
+        if ttl and ttl > 0 then
+            redis.call('EXPIRE', key, ttl)
+        end
+
+        return newVal
+        """;
+
+    /**
+     * SAFE_DECREMENT + EXPIRE 를 하나의 Lua 스크립트에서 처리하여
+     * 감소 연산과 TTL 설정을 원자적으로 보장하기 위한 스크립트입니다.
+     *
+     * KEYS[1] : 대상 key
+     * ARGV[1] : TTL (seconds)
+     */
+    public static final String SAFE_DECREMENT_WITH_TTL = """
+        local key = KEYS[1]
+        local ttl = tonumber(ARGV[1])
+
+        local val = redis.call('GET', key)
+        if not val then
+            return 0
+        end
+
+        local num = tonumber(val)
+        if not num then
+            return 0
+        end
+
+        if num <= 0 then
+            return 0
+        end
+
+        local newVal = redis.call('DECR', key)
+
+        if ttl and ttl > 0 then
+            redis.call('EXPIRE', key, ttl)
+        end
+
+        return newVal
+        """;
+
+    /**
+     * Refresh Token을 원자적으로 조회 및 삭제하는 스크립트입니다.
+     * 1회용 보장을 위해 조회와 삭제를 원자적으로 처리합니다.
+     *
+     * KEYS[1] : 토큰 키 (refreshToken:{token})
+     * KEYS[2] : 메타데이터 키 (refreshToken:{token}:meta)
+     * ARGV[1] : 토큰 값 (Set에서 제거하기 위함)
+     * ARGV[2] : 사용자별 Set 키의 prefix (refreshToken:set:)
+     *
+     * 반환값: [userId, ip, userAgent, remainingTtlMillis] 또는 nil (토큰이 없는 경우)
+     *
+     * <p>동작 방식:
+     * <ol>
+     *   <li>토큰 키에서 userId 조회</li>
+     *   <li>메타데이터(ip, userAgent) 조회</li>
+     *   <li>TTL 계산 (밀리초 단위, PTTL 사용)</li>
+     *   <li>userId를 기반으로 userSetKey 동적 구성: prefix + userId</li>
+     *   <li>토큰, 메타데이터, Set에서 토큰 제거</li>
+     *   <li>결과 반환</li>
+     * </ol>
+     */
+    public static final String GET_AND_DELETE_REFRESH_TOKEN = """
+        local tokenKey = KEYS[1]
+        local metaKey = KEYS[2]
+        local token = ARGV[1]
+        local setKeyPrefix = ARGV[2]
+        
+        -- 토큰 조회 및 삭제 (원자적 연산)
+        local userId = redis.call('GET', tokenKey)
+        if not userId then
+            return nil
+        end
+        
+        -- 메타데이터 조회
+        local ip = redis.call('HGET', metaKey, 'ip')
+        local userAgent = redis.call('HGET', metaKey, 'userAgent')
+        
+        -- TTL 계산 (밀리초 단위, PTTL 사용)
+        local ttl = redis.call('PTTL', tokenKey)
+        local remainingTtlMillis = ttl and ttl > 0 and ttl or 0
+        
+        -- 사용자별 Set 키 동적 구성: prefix + userId
+        local userSetKey = setKeyPrefix .. userId
+        
+        -- 삭제 (원자적 연산)
+        redis.call('DEL', tokenKey)
+        redis.call('DEL', metaKey)
+        redis.call('SREM', userSetKey, token)
+        
+        -- 결과 반환: [userId, ip, userAgent, remainingTtlMillis]
+        return {userId, ip or '', userAgent or '', tostring(remainingTtlMillis)}
+        """;
+
+    /**
+     * OAuth2 임시 토큰을 원자적으로 조회 및 삭제하는 스크립트입니다.
+     * TOCTOU 문제를 방지하기 위해 조회와 삭제를 원자적으로 처리합니다.
+     *
+     * KEYS[1] : 임시 토큰 키
+     *
+     * 반환값: Hash의 모든 필드와 값을 포함한 배열 [field1, value1, field2, value2, ...] 또는 nil (키가 없는 경우)
+     *
+     * <p>동작 방식:
+     * <ol>
+     *   <li>Hash의 모든 필드와 값을 조회</li>
+     *   <li>키 삭제</li>
+     *   <li>결과 반환 (평탄화된 배열: [field1, value1, field2, value2, ...])</li>
+     * </ol>
+     */
+    public static final String GET_AND_DELETE_TEMP_TOKEN = """
+        local key = KEYS[1]
+        
+        -- Hash 조회
+        local entries = redis.call('HGETALL', key)
+        if not entries or #entries == 0 then
+            return nil
+        end
+        
+        -- 키 삭제 (원자적 연산)
+        redis.call('DEL', key)
+        
+        -- 결과 반환 (평탄화된 배열: [field1, value1, field2, value2, ...])
+        return entries
+        """;
+
+    /**
+     * Refresh Token을 원자적으로 삭제하는 스크립트입니다.
+     * 토큰 키, 메타데이터 키, 사용자별 Set에서 토큰을 원자적으로 제거합니다.
+     *
+     * KEYS[1] : 토큰 키 (refreshToken:{token})
+     * KEYS[2] : 메타데이터 키 (refreshToken:{token}:meta)
+     * KEYS[3] : 사용자별 Set 키 (refreshToken:set:{userId})
+     * ARGV[1] : 토큰 값 (Set에서 제거하기 위함)
+     *
+     * 반환값: 삭제된 키의 개수 (0 이상)
+     */
+    public static final String DELETE_REFRESH_TOKEN = """
+        local tokenKey = KEYS[1]
+        local metaKey = KEYS[2]
+        local userSetKey = KEYS[3]
+        local token = ARGV[1]
+        
+        -- 원자적으로 삭제
+        local deletedCount = 0
+        if redis.call('DEL', tokenKey) == 1 then
+            deletedCount = deletedCount + 1
+        end
+        if redis.call('DEL', metaKey) == 1 then
+            deletedCount = deletedCount + 1
+        end
+        if redis.call('SREM', userSetKey, token) == 1 then
+            deletedCount = deletedCount + 1
+        end
+        
+        return deletedCount
+        """;
+
+    /**
+     * 사용자별 모든 Refresh Token을 원자적으로 삭제하는 스크립트입니다.
+     * 사용자별 Set의 모든 토큰과 메타데이터를 조회하여 삭제한 후 Set 자체도 삭제합니다.
+     *
+     * KEYS[1] : 사용자별 Set 키 (refreshToken:set:{userId})
+     * ARGV[1] : 토큰 키 prefix (refreshToken:)
+     *
+     * 반환값: 삭제된 토큰의 개수
+     */
+    public static final String DELETE_ALL_REFRESH_TOKENS_BY_USER = """
+        local userSetKey = KEYS[1]
+        local tokenPrefix = ARGV[1]
+        
+        -- Set에서 모든 토큰 조회
+        local tokens = redis.call('SMEMBERS', userSetKey)
+        if not tokens or #tokens == 0 then
+            -- Set이 비어있거나 없으면 Set만 삭제하고 0 반환
+            redis.call('DEL', userSetKey)
+            return 0
+        end
+        
+        local deletedCount = 0
+        
+        -- 각 토큰과 메타데이터 삭제
+        for i = 1, #tokens do
+            local token = tokens[i]
+            local tokenKey = tokenPrefix .. token
+            local metaKey = tokenKey .. ":meta"
+            
+            if redis.call('DEL', tokenKey) == 1 then
+                deletedCount = deletedCount + 1
+            end
+            redis.call('DEL', metaKey)
+        end
+        
+        -- Set 삭제
+        redis.call('DEL', userSetKey)
+        
+        return deletedCount
+        """;
+
+    /**
+     * 태그 카운트 증가 스크립트 (TTL 포함)
+     * INCR + EXPIRE를 원자적으로 처리합니다.
+     *
+     * KEYS[1] : 태그 카운트 키
+     * ARGV[1] : TTL (seconds)
+     *
+     * 반환값: 증가된 카운트 값
+     */
+    public static final String TAG_COUNT_INCREMENT = """
+        local key = KEYS[1]
+        local ttl = tonumber(ARGV[1])
+        local result = redis.call('INCR', key)
+        if ttl and ttl > 0 then
+            redis.call('EXPIRE', key, ttl)
+        end
+        return result
+        """;
+
+    /**
+     * 태그 카운트 감소 스크립트 (TTL 포함)
+     * 0 이하로 내려가지 않도록 보장하며, EXPIRE를 원자적으로 처리합니다.
+     *
+     * KEYS[1] : 태그 카운트 키
+     * ARGV[1] : TTL (seconds)
+     *
+     * 반환값: 감소된 카운트 값 (0 이상)
+     */
+    public static final String TAG_COUNT_DECREMENT = """
+        local key = KEYS[1]
+        local ttl = tonumber(ARGV[1])
+        local val = redis.call('GET', key)
+        if not val then
+            return 0
+        end
+        local num = tonumber(val)
+        if not num or num <= 0 then
+            return 0
+        end
+        local result = redis.call('DECR', key)
+        if ttl and ttl > 0 then
+            redis.call('EXPIRE', key, ttl)
+        end
+        return result
+        """;
+
+}

--- a/sharedPrompts/src/main/resources/application.yml
+++ b/sharedPrompts/src/main/resources/application.yml
@@ -5,6 +5,7 @@ server:
   port: ${SERVER_PORT:8080}
   servlet:
     context-path: /api
+  shutdown: graceful
 
 # =========================
 # Spring Config
@@ -16,6 +17,9 @@ spring:
   web:
     resources:
       add-mappings: false
+
+  lifecycle:
+    timeout-per-shutdown-phase: ${SHUTDOWN_TIMEOUT:30s}
 
   # =========================
   # OAuth2 클라이언트
@@ -126,6 +130,8 @@ spring:
   # =========================
   ai:
     openai:
+      # ⚠️ 경고: 프로덕션 환경에서는 반드시 실제 API 키를 설정해야 합니다.
+      # 더미 키로는 실제 API 호출이 실패합니다.
       api-key: ${SPRING_AI_OPENAI_API_KEY:dummy-openai-api-key}
 
 # =========================
@@ -300,6 +306,10 @@ rate-limit:
 app:
   redis:
     hot-ttl-seconds: ${APP_REDIS_HOT_TTL_SECONDS:86400}
+  prompt:
+    creation:
+      # 프롬프트 생성 타임아웃 설정 (밀리초)
+      timeout-ms: ${APP_PROMPT_CREATION_TIMEOUT_MS:40000}
 
 # =========================
 # 관리자 유지보수 작업 설정
@@ -339,6 +349,8 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
+      # ⚠️ 보안: 프로덕션 환경에서는 Actuator 엔드포인트에 인증을 추가해야 합니다.
+      # SecurityConfig에서 Actuator 엔드포인트 보안 설정을 확인하세요.
   endpoint:
     health:
       show-details: when-authorized

--- a/sharedPrompts/배포_시_문제점_분석.md
+++ b/sharedPrompts/배포_시_문제점_분석.md
@@ -1,0 +1,427 @@
+# 배포 시 문제점 분석
+
+이 문서는 현재 코드를 프로덕션 환경에 배포할 때 발생할 수 있는 문제점들을 정리한 것입니다.
+
+---
+
+## 🔴 치명적 문제 (배포 전 반드시 해결 필요)
+
+### 1. 필수 환경 변수 누락으로 인한 애플리케이션 시작 실패 ✅ 해결됨
+**위치**: `src/main/resources/application.yml`
+
+**문제점**:
+- 필수 환경 변수에 기본값이 없어 설정 누락 시 애플리케이션이 시작되지 않음
+- 다음 환경 변수들이 필수이지만 기본값이 없음:
+  - `JWT_SECRET` (JWT 토큰 서명 키)
+  - `SPRING_DATASOURCE_URL` (데이터베이스 연결 URL)
+  - `SPRING_DATASOURCE_USERNAME` (데이터베이스 사용자명)
+  - `SPRING_DATASOURCE_PASSWORD` (데이터베이스 비밀번호)
+  - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+  - `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`
+  - `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`
+  - `CORS_ALLOWED_ORIGINS`
+  - `OAUTH2_REDIRECT_FRONT_URL`
+  - `OAUTH2_FAILURE_REDIRECT_URL`
+  - `OAUTH2_SALT`
+  - `GOOGLE_GEMINI_API_KEY`
+
+**영향**: 애플리케이션이 시작되지 않아 서비스 중단
+
+**해결 완료**:
+- ✅ `EnvironmentValidator` 클래스 추가: 애플리케이션 시작 시 필수 환경 변수 자동 검증
+- ✅ 누락된 환경 변수가 있으면 애플리케이션 시작 실패 (IllegalStateException)
+- ✅ 프로덕션 환경에서 localhost 사용 시 경고 로그 출력
+
+---
+
+### 2. 더미 API 키로 인한 외부 서비스 호출 실패 ✅ 해결됨
+**위치**: `src/main/resources/application.yml:129`
+
+**문제점**:
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: ${SPRING_AI_OPENAI_API_KEY:dummy-openai-api-key}
+```
+- OpenAI API 키가 더미 값으로 기본 설정되어 있음
+- 환경 변수가 설정되지 않으면 실제 API 호출 시 실패
+
+**영향**: AI 기능이 동작하지 않음
+
+**해결 완료**:
+- ✅ `application.yml`에 경고 주석 추가
+- ✅ `EnvironmentValidator`에서 프로덕션 환경에서 더미 API 키 사용 시 애플리케이션 시작 실패
+
+---
+
+### 3. 프로덕션 프로필 미활성화로 인한 개발 설정 적용 ✅ 해결됨
+**위치**: `src/main/resources/application-prod.yml`
+
+**문제점**:
+- 프로덕션 프로필이 명시적으로 활성화되지 않으면 개발 환경 설정이 적용될 수 있음
+- `SPRING_PROFILES_ACTIVE=prod` 환경 변수 설정이 필수인데, 누락 시 개발 설정 적용
+
+**영향**: 
+- 개발용 설정(로깅 레벨, 커넥션 풀 크기 등)이 프로덕션에 적용됨
+- 보안 설정이 제대로 적용되지 않을 수 있음
+
+**해결 완료**:
+- ✅ `EnvironmentValidator`에서 프로덕션 환경 감지 시 `prod` 프로필 필수 검증
+- ✅ 프로덕션 환경에서 `prod` 프로필이 없으면 애플리케이션 시작 실패
+
+---
+
+### 4. ShedLock 테이블 미생성으로 인한 스케줄러 비동작
+**위치**: `src/main/resources/application.yml:156`
+
+**문제점**:
+```yaml
+shedlock:
+  table:
+    auto-create: ${SHEDLOCK_TABLE_AUTO_CREATE:false}
+```
+- ShedLock 테이블 자동 생성이 `false`로 설정되어 있음
+- 프로덕션 환경에서 테이블이 없으면 스케줄러가 동작하지 않음
+- `SHEDLOCK_FALLBACK_ENABLED=true`인 경우 DB LockProvider 사용 시 테이블 필수
+
+**영향**: 
+- 배치 작업이 실행되지 않음
+- 스케줄러 기반 기능(통계 집계, 알림 정리 등)이 동작하지 않음
+
+**해결 방안**:
+- 배포 전 `shedlock` 테이블 생성 확인
+- 마이그레이션 스크립트 실행 또는 자동 생성 활성화 (개발 환경에서만)
+
+---
+
+### 5. 알림 시스템 미구현으로 인한 장애 인지 불가 ⏳ 배포 후 추가 예정
+**위치**: 
+- `src/main/java/org/example/sharedprompts/domain/admin/maintenance/rebuild/RebuildNotificationService.java`
+- `src/main/java/org/example/sharedprompts/global/config/async/AsyncExceptionNotifierImpl.java`
+
+**문제점**:
+- 알림 발송 로직이 TODO로 남아있어 실제 알림이 발송되지 않음
+- 비동기 예외 알람 시스템이 미구현 상태
+
+**영향**:
+- 운영 중 문제 발생 시 즉시 인지 불가
+- 장애 대응 시간 지연
+- 재빌드 작업 실패 시 알림을 받을 수 없음
+
+**계획**:
+- ⏳ 배포 후 Slack, Email, PagerDuty 등 실제 알림 시스템 연동 예정
+- 현재는 로그 기반 모니터링으로 대체
+
+---
+
+## 🟠 중요 문제 (배포 전 해결 권장)
+
+### 6. Actuator 엔드포인트 보안 설정 부재 ✅ 해결됨
+**위치**: `src/main/resources/application.yml:337-348`
+
+**문제점**:
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+```
+- Actuator 엔드포인트가 인증 없이 노출됨
+- 프로덕션 환경에서 민감한 정보(메트릭, 상태 정보) 노출 가능
+
+**영향**: 
+- 시스템 정보 유출
+- 보안 취약점
+
+**해결 완료**:
+- ✅ `SecurityPathConstants`에 Actuator 경로 추가
+- ✅ `/actuator/health`는 공개 접근 허용 (헬스 체크용)
+- ✅ `/actuator/info`, `/actuator/metrics`, `/actuator/prometheus`는 관리자(ROLE_ADMIN) 전용으로 설정
+- ✅ `application.yml`에 보안 경고 주석 추가
+
+---
+
+### 7. 데이터베이스 마이그레이션 도구 미설정
+**위치**: `build.gradle`, `src/main/resources/application.yml`
+
+**문제점**:
+- Flyway나 Liquibase 같은 마이그레이션 도구가 설정되어 있지 않음
+- 스키마 변경 시 수동으로 적용해야 함
+
+**영향**:
+- 배포 시 스키마 변경 누락 가능
+- 롤백 시 스키마 복구 어려움
+- 환경별 스키마 불일치 가능
+
+**해결 방안**:
+- Flyway 또는 Liquibase 도입
+- 마이그레이션 스크립트 관리 체계 구축
+
+---
+
+### 8. RabbitMQ 기본 자격 증명 사용
+**위치**: `src/main/resources/application.yml:110-111`
+
+**문제점**:
+```yaml
+rabbitmq:
+  username: ${RABBITMQ_USERNAME:guest}
+  password: ${RABBITMQ_PASSWORD:guest}
+```
+- 기본값이 `guest/guest`로 설정되어 있음
+- 프로덕션 환경에서는 보안상 위험함
+
+**영향**: 보안 취약점
+
+**해결 방안**:
+- 프로덕션 환경에서는 반드시 강력한 자격 증명으로 변경
+- 환경 변수로 관리
+
+---
+
+### 9. Redis/RabbitMQ 호스트 기본값이 localhost
+**위치**: `src/main/resources/application.yml:97, 108`
+
+**문제점**:
+```yaml
+redis:
+  host: ${REDIS_HOST:localhost}
+rabbitmq:
+  host: ${RABBITMQ_HOST:localhost}
+```
+- 기본값이 `localhost`로 설정되어 있음
+- 프로덕션 환경에서는 외부 서비스로 연결해야 하는데 기본값이 로컬이면 연결 실패
+
+**영향**: 
+- 외부 서비스 연결 실패
+- 애플리케이션 시작 실패 가능
+
+**해결 방안**:
+- 프로덕션 환경에서는 반드시 실제 호스트 주소로 설정
+- 환경 변수 필수 설정
+
+---
+
+### 10. Graceful Shutdown 설정 부재 ✅ 해결됨
+**위치**: `src/main/resources/application.yml`
+
+**문제점**:
+- Graceful shutdown 설정이 없음
+- 애플리케이션 종료 시 진행 중인 요청이 중단될 수 있음
+
+**영향**:
+- 데이터 무결성 문제
+- 사용자 요청 실패
+
+**해결 완료**:
+- ✅ `application.yml`에 Graceful Shutdown 설정 추가:
+```yaml
+server:
+  shutdown: graceful
+spring:
+  lifecycle:
+    timeout-per-shutdown-phase: ${SHUTDOWN_TIMEOUT:30s}
+```
+
+---
+
+### 11. 트랜잭션 전파 전략 문제 ✅ 문서화 완료
+**위치**: `src/main/java/org/example/sharedprompts/domain/prompt/service/PromptPersistenceService.java:35`
+
+**문제점**:
+```java
+@Transactional(propagation=REQUIRES_NEW, timeout=30)
+```
+- `REQUIRES_NEW` 사용으로 외부 트랜잭션과 독립적으로 동작
+- 프롬프트 저장이 실패해도 외부 트랜잭션이 롤백되지 않을 수 있음
+
+**영향**: 데이터 일관성 문제
+
+**해결 완료**:
+- ✅ 메서드에 상세한 JavaDoc 주석 추가
+- ✅ 트랜잭션 전파 전략의 의도와 주의사항 문서화
+- ⚠️ 비즈니스 요구사항에 따라 전파 전략 재검토 필요 (향후 개선)
+
+---
+
+### 12. 하드코딩된 타임아웃 값 ✅ 해결됨
+**위치**: `src/main/java/org/example/sharedprompts/domain/prompt/facade/PromptFacade.java`
+
+**문제점**:
+- 타임아웃 값이 하드코딩되어 있음 (`TIMEOUT_MS = 40_000L`)
+- 환경에 따라 적절한 타임아웃 값이 다를 수 있음
+
+**영향**: 환경별 성능 차이
+
+**해결 완료**:
+- ✅ `PromptCreationProperties` 클래스 생성: 타임아웃 값을 설정 파일로 외부화
+- ✅ `application.yml`에 `app.prompt.creation.timeout-ms` 설정 추가 (기본값: 40000ms)
+- ✅ `PromptFacade`에서 설정 값을 주입받아 사용하도록 수정
+
+---
+
+## 🟡 개선 권장 사항
+
+### 13. CORS 설정 검증 필요 ⏳ 추후 처리 예정
+**위치**: `src/main/resources/application.yml:204`
+
+**문제점**:
+- CORS 설정이 환경 변수로만 관리되어 설정 누락 시 CORS 오류 발생 가능
+
+**계획**: 
+- ⏳ 앱 개발 완료 후 CORS 설정 검증 로직 추가 예정
+- 현재는 배포 전 수동으로 CORS 설정 검증 필요
+
+---
+
+### 14. OAuth2 리다이렉트 URL 검증 필요 ✅ 부분 해결됨
+**위치**: `src/main/resources/application.yml:178`
+
+**문제점**:
+- OAuth2 리다이렉트 URL이 환경 변수로 관리되는데, 실제 OAuth 제공자에 등록된 URL과 일치해야 함
+
+**해결 완료**:
+- ✅ `EnvironmentValidator`에서 OAuth2 리다이렉트 URL 형식 검증 추가
+- ✅ URL이 올바른 형식(http:// 또는 https://)인지 확인
+- ⚠️ 실제 OAuth 제공자에 등록된 URL과의 일치 여부는 수동 확인 필요 (자동화 어려움)
+
+---
+
+### 15. 커넥션 풀 크기 최적화 필요 ✅ 경고 추가됨
+**위치**: `src/main/resources/application-prod.yml:22-23`
+
+**문제점**:
+- HikariCP 커넥션 풀 크기가 환경 변수로 설정 가능하지만 기본값이 있음
+- 실제 트래픽에 맞게 조정하지 않으면 커넥션 부족 또는 리소스 낭비 발생
+
+**해결 완료**:
+- ✅ `EnvironmentValidator`에서 프로덕션 환경에서 기본값 사용 시 경고 로그 출력
+- ⚠️ 실제 트래픽에 맞는 최적값은 부하 테스트를 통해 결정 필요
+
+---
+
+### 16. 로깅 설정 최적화 필요 ✅ 검증 추가됨
+**위치**: `src/main/resources/application.yml:387-390`
+
+**문제점**:
+- 로깅 레벨이 환경 변수로 관리되지만 기본값만 설정됨
+- 프로덕션 환경에서 적절한 로깅 레벨 설정 필요
+
+**해결 완료**:
+- ✅ `EnvironmentValidator`에서 프로덕션 환경에서 DEBUG/TRACE 레벨 사용 시 경고 로그 출력
+- ⚠️ 로그 파일 로테이션 및 중앙화된 로그 수집 시스템 연동은 인프라 설정 필요
+
+---
+
+### 17. JPA DDL Auto 설정 검증 필요 ✅ 해결됨
+**위치**: `src/main/resources/application.yml:85`
+
+**문제점**:
+- JPA `ddl-auto`가 기본값 `none`이지만, 개발 환경에서는 `update`로 설정되어 있음
+- 프로덕션 환경에서 실수로 `update`가 설정되면 데이터 손실 위험
+
+**해결 완료**:
+- ✅ `EnvironmentValidator`에서 프로덕션 환경에서 위험한 DDL 설정(update, create, create-drop) 사용 시 애플리케이션 시작 실패
+- ✅ 프로덕션 환경에서는 반드시 `none`으로 설정되어야 함을 강제
+- ⚠️ 마이그레이션 도구(Flyway, Liquibase) 도입은 향후 개선 사항
+
+---
+
+### 18. Health Check 엔드포인트 설정 ✅ 해결됨
+**위치**: `src/main/resources/application.yml:343-344`
+
+**문제점**:
+```yaml
+management:
+  endpoint:
+    health:
+      show-details: when-authorized
+```
+- Health check 상세 정보가 인증 시에만 표시되지만, 인증 설정이 없음
+
+**해결 완료**:
+- ✅ Actuator 엔드포인트 보안 설정 완료 (항목 6 참조)
+- ✅ `/actuator/health`는 공개 접근 허용 (헬스 체크용)
+- ✅ `/actuator/info`, `/actuator/metrics`, `/actuator/prometheus`는 관리자 전용
+- ✅ `show-details: when-authorized` 설정과 Spring Security 인증이 연동됨
+
+---
+
+## 📋 배포 전 체크리스트
+
+### 필수 환경 변수 설정
+- [ ] `JWT_SECRET`
+- [ ] `SPRING_DATASOURCE_URL`
+- [ ] `SPRING_DATASOURCE_USERNAME`
+- [ ] `SPRING_DATASOURCE_PASSWORD`
+- [ ] `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+- [ ] `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`
+- [ ] `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`
+- [ ] `CORS_ALLOWED_ORIGINS`
+- [ ] `OAUTH2_REDIRECT_FRONT_URL`
+- [ ] `OAUTH2_FAILURE_REDIRECT_URL`
+- [ ] `OAUTH2_SALT`
+- [ ] `GOOGLE_GEMINI_API_KEY`
+- [ ] `SPRING_AI_OPENAI_API_KEY`
+
+### 인프라 설정
+- [ ] `SPRING_PROFILES_ACTIVE=prod` 설정
+- [ ] `REDIS_HOST` (프로덕션 Redis 호스트)
+- [ ] `RABBITMQ_HOST` (프로덕션 RabbitMQ 호스트)
+- [ ] `RABBITMQ_USERNAME`, `RABBITMQ_PASSWORD` (강력한 자격 증명)
+- [ ] ShedLock 테이블 생성 확인
+
+### 보안 설정
+- [ ] Actuator 엔드포인트 인증 설정
+- [ ] Health check 엔드포인트 보안 설정
+- [ ] CORS 설정 검증
+- [ ] OAuth2 리다이렉트 URL 검증
+
+### 모니터링 및 알림
+- [ ] 알림 시스템 연동 (Slack, Email 등)
+- [ ] 비동기 예외 알람 시스템 연동
+- [ ] 로그 수집 시스템 연동
+- [ ] 메트릭 수집 시스템 연동 (Prometheus)
+
+### 성능 최적화
+- [ ] 커넥션 풀 크기 조정 (부하 테스트 기반)
+- [ ] Graceful shutdown 설정
+- [ ] 로깅 레벨 최적화
+
+### 데이터베이스
+- [ ] 마이그레이션 도구 설정 (Flyway/Liquibase)
+- [ ] JPA `ddl-auto=none` 확인
+- [ ] 데이터베이스 백업 계획 수립
+
+---
+
+## 🔧 즉시 적용 가능한 개선 사항
+
+### ✅ 완료된 개선 사항
+
+1. **Graceful Shutdown 설정 추가** ✅
+   - `application.yml`에 설정 추가 완료
+
+2. **환경 변수 검증 로직 추가** ✅
+   - `EnvironmentValidator` 클래스 생성 완료
+   - 애플리케이션 시작 시 필수 환경 변수 자동 검증
+
+3. **프로필 검증 로직 추가** ✅
+   - 프로덕션 환경에서 `prod` 프로필 활성화 확인 완료
+
+4. **Actuator 보안 설정** ✅
+   - Actuator 엔드포인트에 관리자 권한 설정 완료
+
+5. **타임아웃 값 외부화** ✅
+   - `PromptFacade`의 타임아웃 값을 설정 파일로 이동 완료
+
+---
+
+## 📝 참고 사항
+
+- 기존 `코드_문제점_분석.md` 파일에 설계 및 코드 품질 관련 문제점이 정리되어 있음
+- 이 문서는 배포 시 발생할 수 있는 운영상의 문제점에 집중함
+- 모든 문제점을 해결한 후 배포하는 것을 권장함
+

--- a/sharedPrompts/코드_문제점_분석.md
+++ b/sharedPrompts/코드_문제점_분석.md
@@ -1,0 +1,109 @@
+# 프로젝트 코드 문제점 분석
+
+## src/main/java/org/example/sharedprompts/domain/admin/maintenance/config/RebuildStatusServiceConfig.java
+- **설계 문제**: 두 개의 Bean 메서드에 모두 `@Primary` 어노테이션이 적용되어 있음. 조건부로 하나만 활성화되지만, 같은 타입에 두 개의 `@Primary`는 Spring 컨테이너에서 모호성을 야기할 수 있음 → 조건부 활성화 시 `@Primary`는 하나만 유지하거나, `@ConditionalOnProperty`만 사용하는 것이 더 명확함
+
+## src/main/java/org/example/sharedprompts/global/config/shcduler/
+- **설계 문제**: 디렉토리 이름에 오타가 있음 (`shcduler` → `scheduler`). 패키지 이름의 오타는 리팩토링 시 모든 import 문을 수정해야 하므로 유지보수성 저하 → 디렉토리 이름을 `scheduler`로 수정 필요
+
+## src/main/java/org/example/sharedprompts/global/config/shcduler/SchedulerConfig.java
+- **설계 문제**: `@Primary` 어노테이션이 두 개의 Bean 메서드에 모두 적용되어 있음. 조건부로 하나만 활성화되지만, 같은 타입에 두 개의 `@Primary`는 모호성을 야기할 수 있음 → 조건부 활성화 시 `@Primary`는 하나만 유지하거나 제거 필요
+
+## src/main/java/org/example/sharedprompts/global/exception/GlobalExceptionHandler.java
+- **설계 문제**: 엔티티 타입을 문자열로 비교하는 하드코딩된 로직 (`entity.getClass().getSimpleName().equals("Report")`). 엔티티 클래스 이름이 변경되면 동작하지 않으며, 타입 안전성이 보장되지 않음 → 엔티티 클래스 타입을 직접 비교하거나 enum을 사용하는 방식으로 개선 필요
+
+## src/main/java/org/example/sharedprompts/controller/admin/AdminController.java
+- **중복 코드**: keyword trim 로직이 `getUsers()`와 `getPrompts()` 메서드에 중복되어 있음 → 공통 유틸리티 메서드나 서비스 레이어로 분리하여 재사용 필요
+
+## src/main/java/org/example/sharedprompts/domain/prompt/service/PromptPersistenceService.java
+- **설계 문제**: `REQUIRES_NEW` 트랜잭션 전파 설정 사용. 새로운 트랜잭션을 생성하므로 외부 트랜잭션과 독립적으로 동작하며, 롤백이 분리됨. 프롬프트 저장이 실패해도 외부 트랜잭션이 롤백되지 않는 문제가 발생할 수 있음 → 트랜잭션 전파 전략 재검토 필요
+
+## src/main/java/org/example/sharedprompts/domain/prompt/facade/PromptFacade.java
+- **설계 문제**: SecurityContext를 직접 조작하는 로직이 Facade에 포함되어 있음. 비즈니스 로직과 보안 컨텍스트 관리가 혼재되어 책임이 분리되지 않음 → SecurityContext 관리는 별도의 유틸리티나 서비스로 분리 필요
+
+## src/main/java/org/example/sharedprompts/domain/like/service/PromptLikeDomainService.java
+- **비효율성**: `validateUserExists()`와 `validatePromptExists()`에서 `existsById()`를 호출한 후, 실제로는 `getReferenceById()`를 사용함. 불필요한 DB 쿼리가 발생함 → `getReferenceById()`만 사용하거나, 검증 로직 제거 필요
+
+## src/main/java/org/example/sharedprompts/domain/prompt/service/PromptGenerator.java
+- **설계 문제**: 프롬프트 템플릿이 하드코딩된 문자열로 구현되어 있음. 템플릿 변경 시 코드 수정이 필요하며, 다국어 지원이나 동적 템플릿 관리가 어려움 → 템플릿을 외부 리소스 파일이나 설정으로 분리 필요
+
+## src/main/java/org/example/sharedprompts/domain/statistics/event/StatisticsCacheEventListener.java
+- **설계 문제**: 캐시 키가 하드코딩된 상수로 정의되어 있음. 캐시 키 관리가 분산되어 있어 일관성 유지가 어려움 → 캐시 키를 중앙화된 관리 클래스로 분리 필요
+
+## src/main/java/org/example/sharedprompts/domain/admin/maintenance/service/AdminMaintenanceServiceImpl.java
+- **설계 문제**: `rebuildLikeCountsFromDbAsync()` 메서드가 너무 많은 책임을 가짐 (상태 관리, 재시도 로직, 알림, 메트릭 수집 등). 단일 책임 원칙 위반 → 각 책임을 별도의 서비스나 컴포넌트로 분리 필요
+
+## src/main/java/org/example/sharedprompts/auth/jwt/filter/JwtAuthenticationFilter.java
+- **설계 문제**: JWT 검증 로직이 필터에 집중되어 있음. 필터가 너무 많은 책임을 가져 테스트와 유지보수가 어려움 → 검증 로직을 별도의 서비스로 분리하여 필터는 오케스트레이션만 담당하도록 개선 필요
+
+## src/main/java/org/example/sharedprompts/global/config/async/AsyncExecutorConfig.java
+- **중복 코드**: `createExecutor()`, `createExecutorWithSecurityContext()`, `createExecutorService()` 메서드 간 유사한 코드가 반복됨 → 공통 로직을 추출하여 중복 제거 필요
+
+## src/main/java/org/example/sharedprompts/global/config/async/config/AsyncConfig.java
+- **비효율성**: `taskExecutor()` 메서드가 `getAsyncExecutor()`에서 다시 호출됨. Bean이 중복 생성될 수 있음 → `getAsyncExecutor()`에서 직접 생성된 Bean을 반환하도록 수정 필요
+
+## src/main/java/org/example/sharedprompts/domain/prompt/service/PromptServiceImpl.java
+- **설계 문제**: `getPromptDetail()` 메서드에서 조회 작업임에도 `@Transactional`을 사용함. `incrementUsageCount()`만 쓰기 작업이므로 `readOnly = true`로 분리하는 것이 더 효율적임 → 조회와 업데이트를 분리하거나 트랜잭션 범위 최적화 필요
+
+## src/main/java/org/example/sharedprompts/domain/auth/service/AuthServiceImpl.java
+- **설계 문제**: `handleSecurityCheckResult()` 메서드가 private 메서드로 구현되어 있지만, 복잡한 보안 검증 로직을 포함함. 보안 관련 로직은 별도의 서비스로 분리하는 것이 더 적절함 → 보안 검증 로직을 별도의 서비스로 분리 필요
+
+## src/main/java/org/example/sharedprompts/controller/prompt/PromptController.java
+- **설계 문제**: `createPrompt()` 메서드에서 `WebAsyncTask`를 직접 사용하여 비동기 처리를 함. 컨트롤러 레이어에서 비동기 처리 로직이 노출되어 있음 → 비동기 처리는 서비스 레이어로 위임하고, 컨트롤러는 동기 응답만 처리하도록 개선 필요
+
+## src/main/java/org/example/sharedprompts/global/aspect/AuditLogAspect.java
+- **설계 문제**: AOP Aspect에서 파라미터 추출 로직이 복잡하게 구현되어 있음. 파라미터 추출 로직이 Aspect에 집중되어 있어 테스트와 유지보수가 어려움 → 파라미터 추출 로직을 별도의 전략 패턴이나 서비스로 분리 필요
+
+## src/main/java/org/example/sharedprompts/domain/tag/count/TagCountMetricService.java
+- **설계 문제**: 문자열 비교를 통한 분기 처리 (`"decrease".equals(operation)`, `"increase".equals(operation)`). 타입 안전성이 보장되지 않으며, 오타 발생 시 런타임 에러 가능 → enum을 사용하여 타입 안전성 확보 필요
+
+## src/main/java/org/example/sharedprompts/domain/admin/maintenance/rebuild/util/LocalRebuildStatusManager.java
+- **설계 문제**: 예외 타입을 `getClass().getSimpleName()`으로 문자열로 변환하여 사용함. 클래스 이름 변경 시 문제가 발생할 수 있음 → 예외 타입을 enum이나 상수로 관리하는 방식으로 개선 필요
+
+## src/main/java/org/example/sharedprompts/global/util/SecurityUtils.java
+- **설계 문제**: 주석에 `String.equals()`의 타이밍 공격 취약점이 언급되어 있지만, 실제 코드에서 이를 해결하는 로직이 보이지 않음 → 타이밍 공격에 안전한 비교 메서드 구현 필요
+
+## src/main/java/org/example/sharedprompts/domain/notification/service/core/NotificationServiceImpl.java
+- **확장성 문제**: 알림 서비스가 여러 책임을 가짐 (알림 생성, 조회, 읽음 처리 등). 새로운 알림 타입 추가 시 코드 수정이 필요함 → 전략 패턴이나 팩토리 패턴을 적용하여 확장성 개선 필요
+
+---
+
+# 배포 시 문제가 될 수 있는 부분
+
+## ⏳ 배포 후 수정 예정
+
+### 알림 시스템
+- **위치**: 
+  - `src/main/java/org/example/sharedprompts/domain/admin/maintenance/rebuild/RebuildNotificationService.java`
+  - `src/main/java/org/example/sharedprompts/global/config/async/AsyncExceptionNotifierImpl.java`
+- **문제점**: 알림 발송 로직이 TODO로 남아있어 실제 배포 시 알림이 발송되지 않음
+- **영향**: 운영 중 문제 발생 시 즉시 인지 불가
+- **계획**: 배포 후 Slack, Email, PagerDuty 등 실제 알림 시스템 연동 예정
+
+### CORS 설정 (앱/웹 분리)
+- **위치**: `src/main/resources/application.yml`
+- **문제점**: CORS 설정이 환경 변수로만 관리되어 있어 앱과 웹의 CORS 정책을 분리하기 어려움
+- **영향**: 앱과 웹의 도메인이 다를 경우 CORS 오류 발생 가능
+- **계획**: 배포 후 앱 개발 완료 시 앱/웹 CORS 정책 분리 구현 예정
+
+### S3 연동
+- **위치**: 파일 업로드/저장 관련 서비스
+- **문제점**: 현재 파일 저장 방식이 명시되지 않았거나 로컬 저장소 사용 중일 가능성
+- **영향**: 확장성 및 안정성 문제
+- **계획**: 배포 후 S3 연동을 통한 파일 저장소 마이그레이션 예정
+
+---
+
+## 🔧 배포 전 수동 확인 필요
+
+### ShedLock 테이블 생성
+- **위치**: `src/main/resources/application.yml`
+- **문제점**: ShedLock 테이블 자동 생성이 기본값으로 `false`로 설정되어 있음. 프로덕션 환경에서 테이블이 없으면 스케줄러가 동작하지 않음
+- **해결 방안**: 배포 전 `shedlock` 테이블 생성 확인 또는 마이그레이션 스크립트 실행 필요
+
+### 데이터베이스 마이그레이션 도구
+- **위치**: `build.gradle`, `src/main/resources/application.yml`
+- **문제점**: Flyway나 Liquibase 같은 마이그레이션 도구가 설정되어 있지 않음
+- **영향**: 스키마 변경 시 수동으로 적용해야 함
+- **계획**: 향후 마이그레이션 도구 도입 예정 (배포 후 개선 사항)
+


### PR DESCRIPTION
개인 통계는 getMyStatistics(Long userId)에서 사용자의 프롬프트 수를 기반으로 계산되므로, 프롬프트 생성/삭제 시 해당 사용자의 캐시("my:{userId}")도 함께 무효화해야 함.

변경 사항:
- StatisticsCacheEventListener에 evictUserStatisticsCache() 메서드 추가
- handlePromptCreated(), handlePromptDeleted()에서 개인 통계 캐시 무효화 호출
- event.userId()를 활용하여 사용자별 캐시 키("my:" + userId) 무효화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 애플리케이션 시작 시 환경 변수 및 설정 검증 기능 추가
  * 우아한 종료(Graceful Shutdown) 메커니즘 구현

* **개선 사항**
  * 헬스 체크 엔드포인트 공개 접근 가능으로 변경
  * 타임아웃 값을 외부 설정으로 관리

* **문서**
  * 배포 시 발생 가능한 문제점 및 해결 방법 문서화
  * 코드 개선 필요 사항 분석 문서 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->