### PR TITLE
RebuildStatusServiceConfig에서 조건부 Bean에 중복된 @Primary 제거

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/SharedPromptsApplication.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/SharedPromptsApplication.java
@@ -1,17 +1,14 @@
 package org.example.sharedprompts;
 
-import org.example.sharedprompts.global.config.PromptCreationProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
 @EnableAsync
 @ConfigurationPropertiesScan  // 전체 패키지 스캔 (환경별 설정 적용을 위해)
-@EnableConfigurationProperties(PromptCreationProperties.class)
 @SpringBootApplication
 public class SharedPromptsApplication {
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/maintenance/config/RebuildStatusServiceConfig.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/maintenance/config/RebuildStatusServiceConfig.java
@@ -7,7 +7,6 @@ import org.example.sharedprompts.domain.admin.maintenance.service.RebuildStatusS
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 /**
@@ -16,30 +15,25 @@ import org.springframework.data.redis.core.StringRedisTemplate;
  */
 @Configuration
 public class RebuildStatusServiceConfig {
-    
+
     /**
      * 글로벌 상태 관리 서비스 (Redis 기반)
-     * useGlobalStatus가 true일 때만 활성화
      */
     @Bean
-    @Primary
     @ConditionalOnProperty(
             name = "admin.maintenance.rebuild.use-global-status",
-            havingValue = "true",
-            matchIfMissing = false
+            havingValue = "true"
     )
     public RebuildStatusService globalRebuildStatusService(
             StringRedisTemplate redisTemplate,
             ObjectMapper objectMapper) {
         return new GlobalRebuildStatusService(redisTemplate, objectMapper);
     }
-    
+
     /**
      * 로컬 상태 관리 서비스 (메모리 기반)
-     * useGlobalStatus가 false이거나 설정되지 않았을 때 사용
      */
     @Bean
-    @Primary
     @ConditionalOnProperty(
             name = "admin.maintenance.rebuild.use-global-status",
             havingValue = "false",

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/response/UserResponseDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/user/response/UserResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.sharedprompts.domain.user.User;
 import org.example.sharedprompts.domain.user.enums.Provider;
+import org.example.sharedprompts.domain.user.enums.Role;
 
 @Getter
 @Builder
@@ -22,6 +23,7 @@ public class UserResponseDto {
     private String nickname;
     private Integer age;
     private String job;
+    private Role role;
     private String thumbnail;
     @JsonProperty("is_signup_completed")
     private boolean isSignupCompleted;
@@ -36,6 +38,7 @@ public class UserResponseDto {
                 .nickname(user.getNickname())
                 .age(user.getAge())
                 .job(user.getJob())
+                .role(user.getRole())
                 .thumbnail(user.getThumbnail())
                 .isSignupCompleted(user.isSignupCompleted())
                 .userTerms(UserTermsResponseDto.from(user.getTerms()))

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/EnvironmentValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/EnvironmentValidator.java
@@ -3,6 +3,8 @@ package org.example.sharedprompts.global.config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 
@@ -23,6 +25,7 @@ import java.util.List;
  * 등록되어야 합니다.
  */
 @Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class EnvironmentValidator implements EnvironmentPostProcessor {
 
     private static final String PROD_PROFILE = "prod";

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.Min;
 
@@ -12,7 +13,7 @@ import javax.validation.constraints.Min;
  */
 @Getter
 @Setter
-@Component
+@Validated
 @ConfigurationProperties(prefix = "app.prompt.creation")
 public class PromptCreationProperties {
     /**

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/PromptCreationProperties.java
@@ -2,6 +2,8 @@ package org.example.sharedprompts.global.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
 import javax.validation.constraints.Min;
 
@@ -10,6 +12,8 @@ import javax.validation.constraints.Min;
  */
 @Getter
 @Setter
+@Component
+@ConfigurationProperties(prefix = "app.prompt.creation")
 public class PromptCreationProperties {
     /**
      * 프롬프트 생성 타임아웃 (밀리초)

--- a/sharedPrompts/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor
+++ b/sharedPrompts/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor
@@ -1,0 +1,2 @@
+org.example.sharedprompts.global.config.EnvironmentValidator
+


### PR DESCRIPTION
@ConditionalOnProperty로 항상 하나의 RebuildStatusService만 등록되므로 @Primary는 불필요하며, 설계상 모호성을 줄이기 위해 제거함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 응답 데이터에 역할(Role) 정보 추가

* **Refactor**
  * 애플리케이션 구성 속성 바인딩 및 검증 지원 추가
  * 서비스 활성화 조건 로직 조정으로 기본 동작 유연성 향상
  * 애플리케이션 시작 시 환경 검증의 우선순위 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->