### PR TITLE
AsyncConfigurer#getAsyncExecutor()에서 @Bean 메서드를 직접 호출하고 있어

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/async/config/AsyncConfig.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/config/async/config/AsyncConfig.java
@@ -19,19 +19,16 @@ import java.util.concurrent.ThreadPoolExecutor;
 /**
  * @EnableAsync의 기본 Executor 설정
  */
-@Slf4j
+@RequiredArgsConstructor
 @Configuration
 @EnableAsync
-@RequiredArgsConstructor
 public class AsyncConfig implements AsyncConfigurer {
 
+    private final Executor taskExecutor; // Bean 주입
     private final AsyncMetricsService asyncMetricsService;
     private final AsyncExceptionNotifier asyncExceptionNotifier;
     private final CriticalMethodChecker criticalMethodChecker;
 
-    /**
-     * @EnableAsync의 기본 Executor
-     */
     @Bean(name = "taskExecutor")
     public Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -49,7 +46,7 @@ public class AsyncConfig implements AsyncConfigurer {
 
     @Override
     public Executor getAsyncExecutor() {
-        return taskExecutor();
+        return taskExecutor;
     }
 
     @Override
@@ -61,3 +58,4 @@ public class AsyncConfig implements AsyncConfigurer {
         );
     }
 }
+


### PR DESCRIPTION
Spring 컨테이너를 우회한 Executor 중복 생성 위험이 있습니다.
동일한 taskExecutor Bean을 주입받아 반환하도록 수정하는 것이 안전합니다