### PR TITLE
fix: Fixed Window Rate Limiting 로직 수정 및 API 표준화

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/FixedWindowRateLimiter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/FixedWindowRateLimiter.java
@@ -58,13 +58,25 @@ public class FixedWindowRateLimiter implements RateLimiter {
             boolean allowed = currentCount <= capacity;
 
             long retryAfter = 0L;
+            
             if (!allowed) {
-                Long ttl = redisTemplate.getExpire(key, TimeUnit.SECONDS);
-                if (ttl == null || ttl < 0) {
-                    ttl = windowSeconds;
+                // 초과 시: TTL을 조회하여 정확한 retryAfter 계산
+                // 예외 발생 시 windowSeconds를 폴백으로 사용
+                try {
+                    Long ttl = redisTemplate.getExpire(key, TimeUnit.SECONDS);
+                    if (ttl != null && ttl > 0) {
+                        retryAfter = ttl;
+                    } else {
+                        // TTL 조회 실패 시 windowSeconds 사용
+                        retryAfter = windowSeconds;
+                    }
+                } catch (Exception e) {
+                    // TTL 조회 실패 시 windowSeconds 사용
+                    retryAfter = windowSeconds;
                 }
-                retryAfter = ttl;
             }
+            // 성공 시: retryAfter는 0으로 유지
+            // reset timestamp는 RateLimitHeaderUtil에서 Redis TTL을 직접 조회하여 계산
 
             return new RateLimitResult(allowed, currentCount, retryAfter);
         } catch (Exception e) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/builder/writer/RateLimitResponseWriter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/builder/writer/RateLimitResponseWriter.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.example.sharedprompts.auth.rate.policy.RateLimitConstants;
+import org.example.sharedprompts.auth.rate.RateLimiter;
+import org.example.sharedprompts.auth.rate.filter.util.RateLimitHeaderUtil;
+import org.example.sharedprompts.auth.rate.policy.RateLimitRule;
 import org.example.sharedprompts.dto.common.CustomResponse;
-import org.example.sharedprompts.global.exception.ApiException;
 import org.example.sharedprompts.global.exception.ErrorCode;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
@@ -18,10 +21,6 @@ import java.io.IOException;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RateLimitResponseWriter {
 
-    /**
-     * HTTP 헤더 이름 상수
-     */
-    private static final String RETRY_AFTER_HEADER = "Retry-After";
     private static final String CHARACTER_ENCODING = "UTF-8";
 
     /**
@@ -29,30 +28,63 @@ public final class RateLimitResponseWriter {
      * 
      * @param response HttpServletResponse
      * @param objectMapper ObjectMapper
-     * @param retryAfterSeconds Retry-After 헤더 값 (초)
+     * @param rule RateLimitRule
+     * @param result RateLimitResult
      * @param errorCode 사용할 에러 코드 (null이면 기본값 RATE_LIMIT_EXCEEDED 사용)
+     * @param redisTemplate RedisTemplate (TTL 조회용, null 가능)
+     * @param rateLimitKey Redis 키 (TTL 조회용, null 가능)
      * @throws IOException 응답 작성 실패 시
      */
     public static void writeTooManyRequests(
             HttpServletResponse response,
             ObjectMapper objectMapper,
-            long retryAfterSeconds,
-            ErrorCode errorCode
+            RateLimitRule rule,
+            RateLimiter.RateLimitResult result,
+            ErrorCode errorCode,
+            @Nullable RedisTemplate<String, Object> redisTemplate,
+            @Nullable String rateLimitKey
     ) throws IOException {
         ErrorCode code = (errorCode != null) ? errorCode : ErrorCode.RATE_LIMIT_EXCEEDED;
-        ApiException exception = new ApiException(code);
-        CustomResponse<Void> body = CustomResponse.fail(exception);
+        
+        // null 안전성 검사 (방어적 프로그래밍)
+        if (result == null) {
+            throw new IllegalArgumentException("RateLimitResult cannot be null");
+        }
+        
+        // RateLimit details 생성 (요구사항: details 필드)
+        // 헤더와 동일한 reset timestamp를 사용하여 일관성 유지
+        long limit = rule.getCapacity();
+        long remaining = Math.max(0, limit - result.currentCount());
+        long retryAfter = result.getRetryAfter(1L);
+        
+        // 헤더와 동일한 방식으로 reset timestamp 계산 (정확성 보장)
+        long resetTimestamp = calculateResetTimestamp(rule, result, redisTemplate, rateLimitKey);
+        
+        java.util.Map<String, Object> details = java.util.Map.of(
+                "limit", limit,
+                "remaining", remaining,
+                "reset", resetTimestamp,
+                "retryAfter", retryAfter
+        );
+        
+        // ExceptionDto에 details 포함
+        org.example.sharedprompts.global.exception.dto.ExceptionDto errorDto = 
+                org.example.sharedprompts.global.exception.dto.ExceptionDto.of(code, null, details);
+        
+        CustomResponse<Void> body = new CustomResponse<>(
+                code.getHttpStatus(),
+                false,
+                null,
+                errorDto
+        );
 
         // HTTP 상태 코드 설정
         response.setStatus(code.getHttpStatus().value());
         
-        // Retry-After 헤더 설정 (RFC 7231)
-        // 최소값으로 클램프하여 0/음수 값 방지
-        long safeRetryAfterSeconds = Math.max(
-                retryAfterSeconds,
-                RateLimitConstants.Response.MIN_RETRY_AFTER_SECONDS
+        // RateLimit 헤더 추가 (요구사항: X-RateLimit-*, Retry-After)
+        RateLimitHeaderUtil.addRateLimitExceededHeaders(
+                response, rule, result, redisTemplate, rateLimitKey
         );
-        response.setHeader(RETRY_AFTER_HEADER, String.valueOf(safeRetryAfterSeconds));
         
         // Content-Type 및 인코딩 설정
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
@@ -63,19 +95,38 @@ public final class RateLimitResponseWriter {
     }
 
     /**
-     * Rate Limit 초과 응답을 작성합니다. (기본 에러 코드 사용)
+     * 리셋 타임스탬프를 계산합니다.
      * 
-     * @param response HttpServletResponse
-     * @param objectMapper ObjectMapper
-     * @param retryAfterSeconds Retry-After 헤더 값 (초)
-     * @throws IOException 응답 작성 실패 시
+     * 헤더와 details 필드에서 동일한 reset timestamp를 사용하여 일관성을 보장합니다.
+     * RateLimitHeaderUtil의 calculateResetTimestamp와 동일한 로직을 사용합니다.
      */
-    public static void writeTooManyRequests(
-            HttpServletResponse response,
-            ObjectMapper objectMapper,
-            long retryAfterSeconds
-    ) throws IOException {
-        writeTooManyRequests(response, objectMapper, retryAfterSeconds, null);
+    private static long calculateResetTimestamp(
+            RateLimitRule rule,
+            RateLimiter.RateLimitResult result,
+            @Nullable RedisTemplate<String, Object> redisTemplate,
+            @Nullable String rateLimitKey
+    ) {
+        long now = java.time.Instant.now().getEpochSecond();
+        
+        // 1. 초과된 요청: retryAfterSeconds를 사용 (이미 TTL 기반으로 계산됨)
+        if (result != null && result.retryAfterSeconds() > 0) {
+            return now + result.retryAfterSeconds();
+        }
+        
+        // 2. 성공한 요청: Redis TTL을 직접 조회하여 정확한 reset 시간 계산
+        if (redisTemplate != null && rateLimitKey != null) {
+            try {
+                Long ttl = redisTemplate.getExpire(rateLimitKey, java.util.concurrent.TimeUnit.SECONDS);
+                if (ttl != null && ttl > 0) {
+                    return now + ttl;
+                }
+            } catch (Exception e) {
+                // TTL 조회 실패 시 폴백 사용 (예외를 무시하고 폴백으로 진행)
+            }
+        }
+        
+        // 3. 폴백: windowSeconds 사용 (정확하지 않을 수 있음)
+        return now + rule.getWindowSeconds();
     }
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/handler/RateLimitExceededFacade.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/handler/RateLimitExceededFacade.java
@@ -9,12 +9,12 @@ import org.example.sharedprompts.auth.rate.filter.metrics.RateLimitMetricsCollec
 import org.example.sharedprompts.auth.rate.filter.model.RateLimitKey;
 import org.example.sharedprompts.auth.rate.policy.RateLimitRule;
 import org.example.sharedprompts.global.exception.ErrorCode;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.function.BiConsumer;
-
-import static org.example.sharedprompts.auth.rate.policy.RateLimitConstants.Response;
 
 /**
  * Rate Limit 초과 처리 Facade
@@ -56,44 +56,28 @@ public class RateLimitExceededFacade {
             RateLimiter.RateLimitResult result,
             HttpServletResponse response,
             BiConsumer<RateLimitKey, RateLimiter.RateLimitResult> logCallback,
-            ErrorCode errorCode
+            ErrorCode errorCode,
+            @Nullable RedisTemplate<String, Object> redisTemplate,
+            @Nullable String rateLimitKey
     ) throws IOException {
-        long retryAfter = result.getRetryAfter(Response.MIN_RETRY_AFTER_SECONDS);
-
         // 1. 메트릭 수집 (Observer 패턴)
         recordMetrics(rule, result);
 
         // 2. 로그 기록 (콜백을 통해)
         recordLog(key, result, logCallback);
 
-        // 3. HTTP 응답 작성
-        writeResponse(response, retryAfter, errorCode);
+        // 3. HTTP 응답 작성 (rule과 result를 직접 전달하여 헤더 포함)
+        RateLimitResponseWriter.writeTooManyRequests(
+                response,
+                objectMapper,
+                rule,
+                result,
+                errorCode,
+                redisTemplate,
+                rateLimitKey
+        );
     }
 
-    /**
-     * Rate Limit 초과를 처리합니다. (기본 에러 코드 사용)
-     * 
-     * @param rule RateLimitRule
-     * @param key Rate Limit 키 (타입 정보 포함)
-     * @param result RateLimitResult
-     * @param response HttpServletResponse
-     * @param logCallback 로그 기록 콜백 (key, result)
-     *                    주의: 이 콜백은 handle() 메서드 내부의 recordLog()에서 호출됩니다.
-     *                    AbstractRateLimitFilter에서는 이미 logRateLimitExceeded()를 통해
-     *                    로깅이 완료되므로, 중복 로깅을 방지하기 위해 빈 람다 (k, r) -> {}를
-     *                    전달하는 것이 일반적입니다. 필요시 추가적인 로깅이나 후처리를
-     *                    수행할 수 있는 확장 포인트로 활용할 수 있습니다.
-     * @throws IOException 응답 작성 실패 시
-     */
-    public void handle(
-            RateLimitRule rule,
-            RateLimitKey key,
-            RateLimiter.RateLimitResult result,
-            HttpServletResponse response,
-            BiConsumer<RateLimitKey, RateLimiter.RateLimitResult> logCallback
-    ) throws IOException {
-        handle(rule, key, result, response, logCallback, null);
-    }
 
     /**
      * 메트릭을 수집합니다.
@@ -120,20 +104,5 @@ public class RateLimitExceededFacade {
         logCallback.accept(key, result);
     }
 
-    /**
-     * HTTP 응답을 작성합니다.
-     * 
-     * @param response HttpServletResponse
-     * @param retryAfter Retry-After 값 (초)
-     * @param errorCode 사용할 에러 코드
-     * @throws IOException 응답 작성 실패 시
-     */
-    private void writeResponse(
-            HttpServletResponse response,
-            long retryAfter,
-            ErrorCode errorCode
-    ) throws IOException {
-        RateLimitResponseWriter.writeTooManyRequests(response, objectMapper, retryAfter, errorCode);
-    }
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/AbstractRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/AbstractRateLimitFilter.java
@@ -11,11 +11,14 @@ import org.example.sharedprompts.auth.rate.filter.model.RateLimitResultWithKey;
 import org.example.sharedprompts.auth.rate.filter.metrics.RateLimitMetricsCollector;
 import org.example.sharedprompts.auth.rate.filter.service.facade.RateLimitFacade;
 import org.example.sharedprompts.auth.rate.filter.strategy.RateLimitKeyStrategy;
+import org.example.sharedprompts.auth.rate.filter.util.RateLimitHeaderUtil;
 import org.example.sharedprompts.auth.rate.policy.RateLimitProperties;
 import org.example.sharedprompts.auth.rate.policy.RateLimitRule;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -32,6 +35,22 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
     protected final RateLimitKeyStrategy keyStrategy;
     protected final RateLimitProperties rateLimitProperties;
     protected final RateLimitMetricsCollector metricsCollector;
+    @Nullable
+    protected final RedisTemplate<String, Object> redisTemplate;
+
+    protected AbstractRateLimitFilter(
+            RateLimitFacade facade,
+            RateLimitKeyStrategy keyStrategy,
+            RateLimitProperties rateLimitProperties,
+            RateLimitMetricsCollector metricsCollector,
+            @Nullable RedisTemplate<String, Object> redisTemplate
+    ) {
+        this.facade = facade;
+        this.keyStrategy = keyStrategy;
+        this.rateLimitProperties = rateLimitProperties;
+        this.metricsCollector = metricsCollector;
+        this.redisTemplate = redisTemplate;
+    }
 
     protected AbstractRateLimitFilter(
             RateLimitFacade facade,
@@ -39,10 +58,7 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
             RateLimitProperties rateLimitProperties,
             RateLimitMetricsCollector metricsCollector
     ) {
-        this.facade = facade;
-        this.keyStrategy = keyStrategy;
-        this.rateLimitProperties = rateLimitProperties;
-        this.metricsCollector = metricsCollector;
+        this(facade, keyStrategy, rateLimitProperties, metricsCollector, null);
     }
 
     @Override
@@ -75,8 +91,31 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
         if (result.isExceeded()) {
             handleRateLimitExceeded(result, context, request, response);
         } else {
+            // 성공 응답에도 RateLimit 헤더 추가 (요구사항)
+            addRateLimitHeaders(response, result);
             filterChain.doFilter(request, response);
         }
+    }
+
+    /**
+     * 성공 응답에 RateLimit 헤더를 추가합니다.
+     * 
+     * @param response HttpServletResponse
+     * @param result RateLimitResultWithKey
+     */
+    private void addRateLimitHeaders(
+            HttpServletResponse response,
+            RateLimitResultWithKey result
+    ) {
+        // Redis 키를 사용하여 정확한 TTL 조회
+        String rateLimitKey = result.getKey() != null ? result.getKey().value() : null;
+        RateLimitHeaderUtil.addRateLimitHeaders(
+                response,
+                result.getRule(),
+                result.getResult(),
+                redisTemplate,
+                rateLimitKey
+        );
     }
 
     /**
@@ -98,12 +137,17 @@ public abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
         );
 
         // Exceeded 응답 처리 (중복 로깅 방지를 위해 빈 콜백 전달)
+        // Redis 키를 사용하여 정확한 TTL 조회
+        String rateLimitKey = result.getKey() != null ? result.getKey().value() : null;
         facade.getExceededFacade().handle(
                 result.getRule(),
                 result.getKey(),
                 result.getResult(),
                 response,
-                (k, r) -> {}
+                (k, r) -> {},
+                null, // errorCode
+                redisTemplate,
+                rateLimitKey
         );
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/IpRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/IpRateLimitFilter.java
@@ -10,6 +10,7 @@ import org.example.sharedprompts.auth.rate.filter.strategy.IpRateLimitKeyStrateg
 import org.example.sharedprompts.auth.rate.policy.RateLimitProperties;
 import org.example.sharedprompts.auth.rate.policy.RateLimitRule;
 import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 /**
@@ -32,9 +33,10 @@ public class IpRateLimitFilter extends AbstractRateLimitFilter {
             RateLimitFacade facade,
             IpRateLimitKeyStrategy keyStrategy,
             RateLimitProperties rateLimitProperties,
-            RateLimitMetricsCollector metricsCollector
+            RateLimitMetricsCollector metricsCollector,
+            RedisTemplate<String, Object> redisTemplate
     ) {
-        super(facade, keyStrategy, rateLimitProperties, metricsCollector);
+        super(facade, keyStrategy, rateLimitProperties, metricsCollector, redisTemplate);
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/UserRateLimitFilter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/impl/UserRateLimitFilter.java
@@ -14,6 +14,7 @@ import org.example.sharedprompts.auth.rate.filter.util.auth.AuthenticationHelper
 import org.example.sharedprompts.auth.rate.policy.RateLimitProperties;
 import org.example.sharedprompts.auth.rate.policy.RateLimitRule;
 import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -38,9 +39,10 @@ public class UserRateLimitFilter extends AbstractRateLimitFilter {
             RateLimitFacade facade,
             UserRateLimitKeyStrategy keyStrategy,
             RateLimitProperties rateLimitProperties,
-            RateLimitMetricsCollector metricsCollector
+            RateLimitMetricsCollector metricsCollector,
+            RedisTemplate<String, Object> redisTemplate
     ) {
-        super(facade, keyStrategy, rateLimitProperties, metricsCollector);
+        super(facade, keyStrategy, rateLimitProperties, metricsCollector, redisTemplate);
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/util/RateLimitHeaderUtil.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/auth/rate/filter/util/RateLimitHeaderUtil.java
@@ -1,0 +1,120 @@
+package org.example.sharedprompts.auth.rate.filter.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.example.sharedprompts.auth.rate.RateLimiter;
+import org.example.sharedprompts.auth.rate.policy.RateLimitRule;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RateLimit HTTP 헤더 유틸리티
+ * 
+ * 요구사항에 맞게 RateLimit 관련 HTTP 헤더를 설정합니다.
+ * - X-RateLimit-Limit: 시간 윈도우당 최대 요청 수
+ * - X-RateLimit-Remaining: 남은 요청 수
+ * - X-RateLimit-Reset: 윈도우 리셋 시간 (Unix timestamp, 초 단위)
+ * - Retry-After: 재시도 가능한 시간 (429 에러 시)
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RateLimitHeaderUtil {
+
+    private static final String HEADER_RATE_LIMIT_LIMIT = "X-RateLimit-Limit";
+    private static final String HEADER_RATE_LIMIT_REMAINING = "X-RateLimit-Remaining";
+    private static final String HEADER_RATE_LIMIT_RESET = "X-RateLimit-Reset";
+    private static final String HEADER_RETRY_AFTER = "Retry-After";
+
+    /**
+     * RateLimit 헤더를 응답에 추가합니다.
+     * 
+     * @param response HttpServletResponse
+     * @param rule RateLimitRule
+     * @param result RateLimitResult (null 가능 - 헤더만 추가)
+     * @param redisTemplate RedisTemplate (TTL 조회용, null 가능)
+     * @param rateLimitKey Redis 키 (TTL 조회용, null 가능)
+     */
+    public static void addRateLimitHeaders(
+            HttpServletResponse response,
+            RateLimitRule rule,
+            RateLimiter.RateLimitResult result,
+            RedisTemplate<String, Object> redisTemplate,
+            String rateLimitKey
+    ) {
+        long limit = rule.getCapacity();
+        long remaining = result != null ? Math.max(0, limit - result.currentCount()) : limit;
+        long resetTimestamp = calculateResetTimestamp(rule, result, redisTemplate, rateLimitKey);
+
+        response.setHeader(HEADER_RATE_LIMIT_LIMIT, String.valueOf(limit));
+        response.setHeader(HEADER_RATE_LIMIT_REMAINING, String.valueOf(remaining));
+        response.setHeader(HEADER_RATE_LIMIT_RESET, String.valueOf(resetTimestamp));
+    }
+
+    /**
+     * RateLimit 초과 시 헤더를 추가합니다 (429 에러용).
+     * 
+     * @param response HttpServletResponse
+     * @param rule RateLimitRule
+     * @param result RateLimitResult
+     * @param redisTemplate RedisTemplate (TTL 조회용, null 가능)
+     * @param rateLimitKey Redis 키 (TTL 조회용, null 가능)
+     */
+    public static void addRateLimitExceededHeaders(
+            HttpServletResponse response,
+            RateLimitRule rule,
+            RateLimiter.RateLimitResult result,
+            RedisTemplate<String, Object> redisTemplate,
+            String rateLimitKey
+    ) {
+        // 기본 RateLimit 헤더 추가
+        addRateLimitHeaders(response, rule, result, redisTemplate, rateLimitKey);
+
+        // Retry-After 헤더 추가
+        long retryAfter = result.getRetryAfter(1L);
+        response.setHeader(HEADER_RETRY_AFTER, String.valueOf(retryAfter));
+    }
+
+    /**
+     * 리셋 타임스탬프를 계산합니다.
+     * 
+     * Fixed Window의 경우: 현재 시간 + Redis TTL (또는 retryAfterSeconds)
+     * 
+     * @param rule RateLimitRule
+     * @param result RateLimitResult (null 가능)
+     * @param redisTemplate RedisTemplate (TTL 조회용, null 가능)
+     * @param rateLimitKey Redis 키 (TTL 조회용, null 가능)
+     * @return Unix timestamp (초 단위)
+     */
+    private static long calculateResetTimestamp(
+            RateLimitRule rule,
+            RateLimiter.RateLimitResult result,
+            RedisTemplate<String, Object> redisTemplate,
+            String rateLimitKey
+    ) {
+        long now = Instant.now().getEpochSecond();
+        
+        // 1. 초과된 요청: retryAfterSeconds를 사용 (이미 TTL 기반으로 계산됨)
+        if (result != null && result.retryAfterSeconds() > 0) {
+            return now + result.retryAfterSeconds();
+        }
+        
+        // 2. 성공한 요청: Redis TTL을 직접 조회하여 정확한 reset 시간 계산
+        if (redisTemplate != null && rateLimitKey != null) {
+            try {
+                Long ttl = redisTemplate.getExpire(rateLimitKey, TimeUnit.SECONDS);
+                if (ttl != null && ttl > 0) {
+                    return now + ttl;
+                }
+            } catch (Exception e) {
+                // TTL 조회 실패 시 폴백 사용 (예외를 무시하고 폴백으로 진행)
+            }
+        }
+        
+        // 3. 폴백: windowSeconds 사용 (정확하지 않을 수 있음)
+        return now + rule.getWindowSeconds();
+    }
+}
+
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/dto/ExceptionDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/exception/dto/ExceptionDto.java
@@ -1,10 +1,14 @@
 package org.example.sharedprompts.global.exception.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import org.example.sharedprompts.global.exception.ErrorCode;
 
+import java.util.Map;
+
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExceptionDto {
 
     @NotNull
@@ -15,14 +19,25 @@ public class ExceptionDto {
 
     private final String field;
 
-    public ExceptionDto(ErrorCode errorCode, String field) {
+    private final Map<String, Object> details;
+
+    public ExceptionDto(ErrorCode errorCode, String field, Map<String, Object> details) {
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
         this.field = field;
+        this.details = details;
+    }
+
+    public ExceptionDto(ErrorCode errorCode, String field) {
+        this(errorCode, field, null);
     }
 
     public ExceptionDto(ErrorCode errorCode) {
-        this(errorCode, null);
+        this(errorCode, null, null);
+    }
+
+    public static ExceptionDto of(ErrorCode errorCode, String field, Map<String, Object> details) {
+        return new ExceptionDto(errorCode, field, details);
     }
 
     public static ExceptionDto of(ErrorCode errorCode, String field) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/lua/LuaScripts.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/lua/LuaScripts.java
@@ -27,6 +27,10 @@ public class LuaScripts {
     /**
      * INCR + EXPIRE 를 하나의 Lua 스크립트에서 처리하여
      * TTL 설정까지 원자적으로 보장하기 위한 스크립트입니다.
+     * 
+     * Fixed Window Rate Limiting을 위해:
+     * - 키가 없을 때만 EXPIRE를 설정합니다 (TTL 갱신 방지)
+     * - 키가 이미 있으면 TTL을 변경하지 않아 윈도우가 정확히 리셋됩니다.
      *
      * KEYS[1] : 대상 key
      * ARGV[1] : TTL (seconds)
@@ -37,7 +41,9 @@ public class LuaScripts {
 
         local newVal = redis.call('INCR', key)
 
-        if ttl and ttl > 0 then
+        -- Fixed Window: 키가 없을 때만 TTL 설정 (키가 이미 있으면 TTL 유지)
+        -- newVal == 1이면 키가 방금 생성된 것이므로 TTL 설정
+        if newVal == 1 and ttl and ttl > 0 then
             redis.call('EXPIRE', key, ttl)
         end
 


### PR DESCRIPTION
- Fixed Window Rate Limiting 정확성 보장
  * Lua 스크립트에서 TTL 설정을 newVal == 1일 때만 수행하도록 수정
  * 키 만료 후 윈도우 리셋이 정확히 동작하도록 개선

- RateLimit 헤더 추가 및 표준화
  * 모든 API 응답에 X-RateLimit-* 헤더 추가
  * 429 에러 시 Retry-After 헤더 추가
  * Redis TTL 기반 정확한 reset timestamp 계산

- 표준화된 에러 응답 형식
  * 429 에러 응답에 details 필드 추가 (limit, remaining, reset, retryAfter)
  * ExceptionDto에 details 필드 지원 추가

- 예외 처리 개선
  * Redis TTL 조회 실패 시 폴백 처리
  * null 안전성 검사 추가

- 코드 정리
  * RateLimitHeaderUtil 유틸리티 클래스 추가
  * 레거시 메서드 및 중복 코드 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 응답에 현재 사용량과 재설정 시간 정보를 포함하는 속도 제한 관련 헤더가 추가되었습니다.

* **버그 수정**
  * 속도 제한 초과 시 정확한 재시도 시간을 제공합니다.
  * 속도 제한 초과 시 오류 응답에 제한값, 남은 요청 횟수, 재설정 시간 등의 상세 정보를 포함합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->