### PR TITLE
멱등성 체크가 원자적이지 않아 중복 처리 위험이 있습니다.

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/webhook/WebhookHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/webhook/WebhookHandler.java
@@ -55,48 +55,56 @@ public class WebhookHandler {
         // 3. Webhook 파싱
         PaymentProvider.WebhookEvent event = provider.parseWebhook(payload);
         
-        // 4. 멱등성 확인 (Webhook ID 기반)
+        // 4. 멱등성 확인 (Webhook ID 기반) - 원자적 락 획득
         String webhookId = generateWebhookId(paymentMethod, event);
-        if (idempotencyService.isAlreadyProcessed(webhookId)) {
+        if (!idempotencyService.tryProcess(webhookId)) {
             log.info("Webhook 이미 처리됨: webhookId={}, externalPaymentId={}", 
                     webhookId, event.externalPaymentId());
             return paymentRepository.findByExternalPaymentId(event.externalPaymentId());
         }
         
-        // 5. Payment 조회
-        Optional<Payment> paymentOpt = paymentRepository.findByExternalPaymentId(event.externalPaymentId());
-        if (paymentOpt.isEmpty()) {
-            log.warn("Webhook 수신했으나 Payment를 찾을 수 없음: externalPaymentId={}", 
-                    event.externalPaymentId());
-            // Webhook ID는 저장하여 중복 처리 방지
+        try {
+            // 5. Payment 조회
+            Optional<Payment> paymentOpt = paymentRepository.findByExternalPaymentId(event.externalPaymentId());
+            if (paymentOpt.isEmpty()) {
+                log.warn("Webhook 수신했으나 Payment를 찾을 수 없음: externalPaymentId={}", 
+                        event.externalPaymentId());
+                // Webhook ID는 저장하여 중복 처리 방지
+                idempotencyService.markAsProcessed(webhookId);
+                return Optional.empty();
+            }
+            
+            Payment payment = paymentOpt.get();
+            
+            // 6. 이미 SUCCESS 상태면 재처리하지 않음 (멱등성)
+            if (payment.getStatus().isCompleted()) {
+                log.info("Payment가 이미 완료 상태: paymentId={}, status={}, externalPaymentId={}", 
+                        payment.getId(), payment.getStatus(), event.externalPaymentId());
+                idempotencyService.markAsProcessed(webhookId);
+                return Optional.of(payment);
+            }
+            
+            // 7. PaymentResult 검증
+            if (event.paymentResult() != null) {
+                // 실제 결제 금액 계산 (포인트 사용 후 금액)
+                BigDecimal actualAmount = payment.getAmount().subtract(
+                        payment.getUsedPointAmount() != null ? payment.getUsedPointAmount() : java.math.BigDecimal.ZERO
+                );
+                paymentValidator.validatePaymentResult(payment, event.paymentResult(), actualAmount);
+            }
+            
+            // 8. Webhook ID 저장 (멱등성 보장) - 검증 성공 후 마킹
             idempotencyService.markAsProcessed(webhookId);
-            return Optional.empty();
-        }
-        
-        Payment payment = paymentOpt.get();
-        
-        // 6. 이미 SUCCESS 상태면 재처리하지 않음 (멱등성)
-        if (payment.getStatus().isCompleted()) {
-            log.info("Payment가 이미 완료 상태: paymentId={}, status={}, externalPaymentId={}", 
-                    payment.getId(), payment.getStatus(), event.externalPaymentId());
-            idempotencyService.markAsProcessed(webhookId);
+            
+            // 9. Payment 반환 (실제 상태 변경은 PaymentService에서 처리)
             return Optional.of(payment);
+        } catch (Exception e) {
+            // 처리 실패 시 락 해제
+            idempotencyService.releaseProcessingLock(webhookId);
+            log.error("Webhook 처리 중 오류 발생: webhookId={}, externalPaymentId={}", 
+                    webhookId, event.externalPaymentId(), e);
+            throw e;
         }
-        
-        // 7. PaymentResult 검증
-        if (event.paymentResult() != null) {
-            // 실제 결제 금액 계산 (포인트 사용 후 금액)
-            BigDecimal actualAmount = payment.getAmount().subtract(
-                    payment.getUsedPointAmount() != null ? payment.getUsedPointAmount() : java.math.BigDecimal.ZERO
-            );
-            paymentValidator.validatePaymentResult(payment, event.paymentResult(), actualAmount);
-        }
-        
-        // 8. Webhook ID 저장 (멱등성 보장)
-        idempotencyService.markAsProcessed(webhookId);
-        
-        // 9. Payment 반환 (실제 상태 변경은 PaymentService에서 처리)
-        return Optional.of(payment);
     }
     
     /**


### PR DESCRIPTION
isAlreadyProcessed()는 비원자적이라 동시에 들어오는 웹훅이 모두 통과할 수 있습니다. tryProcess()로 락을 잡고 실패 시 releaseProcessingLock()로 해제하는 방식이 안전합니다. 또한 실제 상태 변경이 성공한 뒤에 markAsProcessed()를 호출하도록 위치를 조정하는 편이 좋습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 결제 웹훅 처리 시 원자적 잠금 메커니즘을 통한 중복 처리 방지 개선
  * 결제 데이터 누락 시 에러 처리 로직 강화
  * 완료된 결제 상태에 대한 안정적인 처리 추가
  * 결제 유효성 검증 단계 도입
  * 에러 발생 시 안전한 리소스 해제 메커니즘 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->