### PR TITLE
feat: Redis 모니터링 및 알림 기능 추가

### DIFF
--- a/sharedPrompts/Postman_Collection.json
+++ b/sharedPrompts/Postman_Collection.json
@@ -74,7 +74,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"email\": \"test@example.com\",\n  \"password\": \"password123\"\n}"
+              "raw": "{\n  \"email\": \"test@example.com\",\n  \"password\": \"password123\",\n  \"device_token\": \"device_token_value\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/auth/login",
@@ -101,27 +101,6 @@
               "raw": "{{baseUrl}}/auth/confirm",
               "host": ["{{baseUrl}}"],
               "path": ["auth", "confirm"]
-            }
-          }
-        },
-        {
-          "name": "OAuth 콜백",
-          "request": {
-            "method": "GET",
-            "url": {
-              "raw": "{{baseUrl}}/auth/callback?key=oauth_key&state=state_value",
-              "host": ["{{baseUrl}}"],
-              "path": ["auth", "callback"],
-              "query": [
-                {
-                  "key": "key",
-                  "value": "oauth_key"
-                },
-                {
-                  "key": "state",
-                  "value": "state_value"
-                }
-              ]
             }
           }
         },
@@ -1385,7 +1364,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"paymentId\": \"1\",\n  \"reason\": \"사용자 요청\"\n}"
+              "raw": "{\n  \"payment_id\": \"1\",\n  \"reason\": \"사용자 요청\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/payments/cancel",
@@ -1410,7 +1389,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"paymentId\": \"1\",\n  \"amount\": null,\n  \"reason\": \"사용자 요청\"\n}"
+              "raw": "{\n  \"payment_id\": \"1\",\n  \"amount\": null,\n  \"reason\": \"사용자 요청\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/payments/refund",
@@ -1420,18 +1399,7 @@
           }
         },
         {
-          "name": "사용자 티어 조회",
-          "request": {
-            "method": "GET",
-            "url": {
-              "raw": "{{baseUrl}}/payments/users/1/tier",
-              "host": ["{{baseUrl}}"],
-              "path": ["payments", "users", "1", "tier"]
-            }
-          }
-        },
-        {
-          "name": "사용자 티어 정보 조회",
+          "name": "내 티어 조회",
           "request": {
             "method": "GET",
             "header": [
@@ -1441,9 +1409,26 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/payments/users/1/tier-info",
+              "raw": "{{baseUrl}}/payments/me/tier",
               "host": ["{{baseUrl}}"],
-              "path": ["payments", "users", "1", "tier-info"]
+              "path": ["payments", "me", "tier"]
+            }
+          }
+        },
+        {
+          "name": "내 티어 정보 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/payments/me/tier-info",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "me", "tier-info"]
             }
           }
         },
@@ -1465,7 +1450,7 @@
           }
         },
         {
-          "name": "티어 변경 이력 조회",
+          "name": "내 티어 변경 이력 조회",
           "request": {
             "method": "GET",
             "header": [
@@ -1475,9 +1460,34 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/payments/users/1/tier-history",
+              "raw": "{{baseUrl}}/payments/me/tier-history",
               "host": ["{{baseUrl}}"],
-              "path": ["payments", "users", "1", "tier-history"]
+              "path": ["payments", "me", "tier-history"]
+            }
+          }
+        },
+        {
+          "name": "결제 승인",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"order_id\": \"1\",\n  \"amount\": 10000,\n  \"payment_key\": \"payment_key_value\",\n  \"pg_token\": \"pg_token_value\",\n  \"toss_order_id\": \"toss_order_id_value\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments/confirm",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "confirm"]
             }
           }
         }
@@ -2174,6 +2184,188 @@
         {
           "name": "결제 관리",
           "item": [
+            {
+              "name": "결제 상태 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/1/status",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "1", "status"]
+                }
+              }
+            },
+            {
+              "name": "사용자 결제 내역 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/users/1/history?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "users", "1", "history"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "전체 결제 내역 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/history?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "history"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "결제 취소",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"reason\": \"관리자 요청\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/1/cancel",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "1", "cancel"]
+                }
+              }
+            },
+            {
+              "name": "결제 환불",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"amount\": null,\n  \"reason\": \"관리자 요청\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/1/refund",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "1", "refund"]
+                }
+              }
+            },
+            {
+              "name": "사용자 티어 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/users/1/tier",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "users", "1", "tier"]
+                }
+              }
+            },
+            {
+              "name": "사용자 티어 정보 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/users/1/tier-info",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "users", "1", "tier-info"]
+                }
+              }
+            },
+            {
+              "name": "사용자 티어 변경 이력 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/payments/users/1/tier-history?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "payments", "users", "1", "tier-history"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            },
             {
               "name": "사용자 티어 변경",
               "request": {

--- a/sharedPrompts/Postman_Collection.json
+++ b/sharedPrompts/Postman_Collection.json
@@ -2431,6 +2431,79 @@
               }
             }
           ]
+        },
+        {
+          "name": "Redis 관리",
+          "item": [
+            {
+              "name": "Redis 상태 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/redis/status",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "redis", "status"]
+                }
+              }
+            },
+            {
+              "name": "Redis 재시작",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/redis/restart",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "redis", "restart"]
+                }
+              }
+            },
+            {
+              "name": "Redis 연결 테스트",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/redis/test-connection",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "redis", "test-connection"]
+                }
+              }
+            },
+            {
+              "name": "Redis Health Check",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/redis/health-check",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "redis", "health-check"]
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/sharedPrompts/docs/TOSS_PAYMENT_KEY_ERROR_ANALYSIS.md
+++ b/sharedPrompts/docs/TOSS_PAYMENT_KEY_ERROR_ANALYSIS.md
@@ -752,3 +752,4 @@ async function confirmTossPaymentWrong(orderId, amount) {
 
 
 
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/controller/admin/AdminRedisController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/controller/admin/AdminRedisController.java
@@ -1,0 +1,81 @@
+package org.example.sharedprompts.controller.admin;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.domain.admin.service.RedisManagementService;
+import org.example.sharedprompts.domain.auth.AuthUser;
+import org.example.sharedprompts.domain.auth.CurrentUser;
+import org.example.sharedprompts.dto.admin.response.RedisStatusResponseDto;
+import org.example.sharedprompts.global.annotation.AdminOnly;
+import org.example.sharedprompts.dto.common.CustomResponse;
+import org.example.sharedprompts.dto.common.CustomResponseHelper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@AdminOnly
+@RestController
+@RequestMapping("/admin/redis")
+@RequiredArgsConstructor
+public class AdminRedisController {
+
+    private final RedisManagementService redisManagementService;
+
+    @GetMapping("/status")
+    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> getRedisStatus() {
+        boolean isHealthy = redisManagementService.checkRedisStatus();
+        boolean connectionTest = redisManagementService.testRedisConnection();
+        
+        RedisStatusResponseDto response = RedisStatusResponseDto.builder()
+                .healthy(isHealthy)
+                .connected(connectionTest)
+                .build();
+        
+        return CustomResponseHelper.ok(response);
+    }
+
+    @PostMapping("/restart")
+    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> restartRedis(
+            @CurrentUser AuthUser authUser
+    ) {
+        log.info("관리자 Redis 재시작 요청: userId={}", authUser.getId());
+        
+        boolean success = redisManagementService.restartRedis();
+        boolean connectionTest = redisManagementService.testRedisConnection();
+        
+        RedisStatusResponseDto response = RedisStatusResponseDto.builder()
+                .healthy(success && connectionTest)
+                .connected(connectionTest)
+                .message(success ? "Redis 재시작 시도가 완료되었습니다." : "Redis 재시작 시도에 실패했습니다.")
+                .build();
+        
+        return CustomResponseHelper.ok(response);
+    }
+
+    @PostMapping("/test-connection")
+    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> testConnection() {
+        boolean connected = redisManagementService.testRedisConnection();
+        
+        RedisStatusResponseDto response = RedisStatusResponseDto.builder()
+                .healthy(connected)
+                .connected(connected)
+                .message(connected ? "Redis 연결이 정상입니다." : "Redis 연결에 실패했습니다.")
+                .build();
+        
+        return CustomResponseHelper.ok(response);
+    }
+
+    @PostMapping("/health-check")
+    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> performHealthCheck() {
+        boolean isHealthy = redisManagementService.performHealthCheck();
+        
+        RedisStatusResponseDto response = RedisStatusResponseDto.builder()
+                .healthy(isHealthy)
+                .connected(isHealthy)
+                .message(isHealthy ? "Redis Health Check 통과" : "Redis Health Check 실패")
+                .build();
+        
+        return CustomResponseHelper.ok(response);
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/controller/admin/AdminRedisController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/controller/admin/AdminRedisController.java
@@ -39,19 +39,23 @@ public class AdminRedisController {
     ) {
         log.info("관리자 Redis 재시작 요청: userId={}", authUser.getId());
         
-        boolean success = redisManagementService.restartRedis();
-        
+        // 비동기 작업 시작, 즉시 응답 반환
+        redisManagementService.restartRedis();
         RedisStatusResponseDto response = RedisStatusResponseDto.builder()
-                .healthy(success)
-                .connected(success)
-                .message(success ? "Redis 재시작 시도가 완료되었습니다." : "Redis 재시작 시도에 실패했습니다.")
+                .healthy(false)
+                .connected(false)
+                .message("Redis 재시작이 비동기로 시작되었습니다. 상태를 확인하려면 /admin/redis/status를 사용하세요.")
                 .build();
         
         return CustomResponseHelper.ok(response);
     }
 
     @PostMapping("/test-connection")
-    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> testConnection() {
+    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> testConnection(
+            @CurrentUser AuthUser authUser
+    ) {
+        log.info("관리자 Redis 연결 테스트 요청: userId={}", authUser.getId());
+        
         boolean connected = redisManagementService.testRedisConnection();
         
         RedisStatusResponseDto response = RedisStatusResponseDto.builder()
@@ -64,7 +68,11 @@ public class AdminRedisController {
     }
 
     @PostMapping("/health-check")
-    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> performHealthCheck() {
+    public ResponseEntity<CustomResponse<RedisStatusResponseDto>> performHealthCheck(
+            @CurrentUser AuthUser authUser
+    ) {
+        log.info("관리자 Redis Health Check 요청: userId={}", authUser.getId());
+        
         boolean isHealthy = redisManagementService.performHealthCheck();
         
         RedisStatusResponseDto response = RedisStatusResponseDto.builder()

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/controller/admin/AdminRedisController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/controller/admin/AdminRedisController.java
@@ -24,11 +24,10 @@ public class AdminRedisController {
     @GetMapping("/status")
     public ResponseEntity<CustomResponse<RedisStatusResponseDto>> getRedisStatus() {
         boolean isHealthy = redisManagementService.checkRedisStatus();
-        boolean connectionTest = redisManagementService.testRedisConnection();
         
         RedisStatusResponseDto response = RedisStatusResponseDto.builder()
                 .healthy(isHealthy)
-                .connected(connectionTest)
+                .connected(isHealthy)
                 .build();
         
         return CustomResponseHelper.ok(response);
@@ -41,11 +40,10 @@ public class AdminRedisController {
         log.info("관리자 Redis 재시작 요청: userId={}", authUser.getId());
         
         boolean success = redisManagementService.restartRedis();
-        boolean connectionTest = redisManagementService.testRedisConnection();
         
         RedisStatusResponseDto response = RedisStatusResponseDto.builder()
-                .healthy(success && connectionTest)
-                .connected(connectionTest)
+                .healthy(success)
+                .connected(success)
                 .message(success ? "Redis 재시작 시도가 완료되었습니다." : "Redis 재시작 시도에 실패했습니다.")
                 .build();
         

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/service/RedisManagementService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/service/RedisManagementService.java
@@ -4,12 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.global.redis.RedisHealthService;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisCallback;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 public class RedisManagementService {
 
     private final RedisHealthService redisHealthService;
-    private final StringRedisTemplate redisTemplate;
     
     @Value("${redis.restart.command:}")
     private String restartCommand;
@@ -80,15 +79,13 @@ public class RedisManagementService {
         try {
             log.info("Redis 재시작 명령어 실행: {}", restartCommand);
             
-            ProcessBuilder processBuilder;
-            String os = System.getProperty("os.name").toLowerCase();
-            
-            if (os.contains("win")) {
-                processBuilder = new ProcessBuilder("cmd", "/c", restartCommand);
-            } else {
-                processBuilder = new ProcessBuilder("sh", "-c", restartCommand);
+            List<String> commandParts = parseCommand(restartCommand);
+            if (commandParts.isEmpty()) {
+                log.error("Redis 재시작 명령어 파싱 실패: 빈 명령어");
+                return false;
             }
             
+            ProcessBuilder processBuilder = new ProcessBuilder(commandParts);
             processBuilder.redirectErrorStream(true);
             Process process = processBuilder.start();
             
@@ -126,31 +123,46 @@ public class RedisManagementService {
     }
 
     public boolean testRedisConnection() {
-        try {
-            String result = redisTemplate.execute((RedisCallback<String>) connection -> {
-                return connection.ping();
-            });
-            
-            boolean isConnected = "PONG".equals(result);
-            
-            if (isConnected) {
-                log.info("Redis 연결 테스트 성공");
-                redisHealthService.setHealthy(true);
-            } else {
-                log.warn("Redis 연결 테스트 실패: PING 응답이 PONG이 아님");
-                redisHealthService.setHealthy(false);
-            }
-            
-            return isConnected;
-        } catch (Exception e) {
-            log.error("Redis 연결 테스트 중 예외 발생", e);
-            redisHealthService.setHealthy(false);
-            return false;
-        }
+        return redisHealthService.forceHealthCheck();
     }
 
     public boolean performHealthCheck() {
         return redisHealthService.forceHealthCheck();
+    }
+
+    private List<String> parseCommand(String command) {
+        List<String> parts = new ArrayList<>();
+        if (command == null || command.trim().isEmpty()) {
+            return parts;
+        }
+        
+        // 공백으로 분리하되, 따옴표로 감싸진 부분은 보존
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        StringBuilder current = new StringBuilder();
+        
+        for (int i = 0; i < command.length(); i++) {
+            char c = command.charAt(i);
+            
+            if (c == '\'' && !inDoubleQuote) {
+                inSingleQuote = !inSingleQuote;
+            } else if (c == '"' && !inSingleQuote) {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (Character.isWhitespace(c) && !inSingleQuote && !inDoubleQuote) {
+                if (current.length() > 0) {
+                    parts.add(current.toString());
+                    current.setLength(0);
+                }
+            } else {
+                current.append(c);
+            }
+        }
+        
+        if (current.length() > 0) {
+            parts.add(current.toString());
+        }
+        
+        return parts;
     }
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/service/RedisManagementService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/service/RedisManagementService.java
@@ -4,12 +4,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.global.redis.RedisHealthService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -32,17 +34,18 @@ public class RedisManagementService {
         return redisHealthService.getCachedHealthStatus();
     }
 
-    public boolean restartRedis() {
+    @Async
+    public CompletableFuture<Boolean> restartRedis() {
         log.info("Redis 재시작 시도 시작");
         
         if (!restartEnabled) {
             log.warn("Redis 재시작 기능이 비활성화되어 있습니다. redis.restart.enabled=true로 설정하세요.");
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
         
         if (restartCommand == null || restartCommand.trim().isEmpty()) {
             log.warn("Redis 재시작 명령어가 설정되지 않았습니다. redis.restart.command를 설정하세요.");
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
         
         try {
@@ -50,7 +53,7 @@ public class RedisManagementService {
             
             if (!restartSuccess) {
                 log.error("Redis 재시작 명령어 실행 실패");
-                return false;
+                return CompletableFuture.completedFuture(false);
             }
             
             Thread.sleep(3000);
@@ -59,7 +62,7 @@ public class RedisManagementService {
                 boolean isHealthy = redisHealthService.forceHealthCheck();
                 if (isHealthy) {
                     log.info("Redis 재시작 성공: 연결 확인 완료 (시도 횟수: {})", i + 1);
-                    return true;
+                    return CompletableFuture.completedFuture(true);
                 }
                 if (i < 4) {
                     Thread.sleep(2000);
@@ -67,17 +70,17 @@ public class RedisManagementService {
             }
             
             log.warn("Redis 재시작 후 연결 확인 실패");
-            return false;
+            return CompletableFuture.completedFuture(false);
             
         } catch (Exception e) {
             log.error("Redis 재시작 시도 중 예외 발생", e);
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
     }
     
     private boolean executeRestartCommand() {
         try {
-            log.info("Redis 재시작 명령어 실행: {}", restartCommand);
+            log.debug("Redis 재시작 명령어 실행: {}", restartCommand);
             
             List<String> commandParts = parseCommand(restartCommand);
             if (commandParts.isEmpty()) {
@@ -127,7 +130,7 @@ public class RedisManagementService {
     }
 
     public boolean performHealthCheck() {
-        return redisHealthService.forceHealthCheck();
+        return testRedisConnection();
     }
 
     private List<String> parseCommand(String command) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/service/RedisManagementService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/admin/service/RedisManagementService.java
@@ -1,0 +1,156 @@
+package org.example.sharedprompts.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.global.redis.RedisHealthService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisManagementService {
+
+    private final RedisHealthService redisHealthService;
+    private final StringRedisTemplate redisTemplate;
+    
+    @Value("${redis.restart.command:}")
+    private String restartCommand;
+    
+    @Value("${redis.restart.enabled:false}")
+    private boolean restartEnabled;
+    
+    @Value("${redis.restart.timeout-seconds:30}")
+    private int restartTimeoutSeconds;
+
+    public boolean checkRedisStatus() {
+        return redisHealthService.getCachedHealthStatus();
+    }
+
+    public boolean restartRedis() {
+        log.info("Redis 재시작 시도 시작");
+        
+        if (!restartEnabled) {
+            log.warn("Redis 재시작 기능이 비활성화되어 있습니다. redis.restart.enabled=true로 설정하세요.");
+            return false;
+        }
+        
+        if (restartCommand == null || restartCommand.trim().isEmpty()) {
+            log.warn("Redis 재시작 명령어가 설정되지 않았습니다. redis.restart.command를 설정하세요.");
+            return false;
+        }
+        
+        try {
+            boolean restartSuccess = executeRestartCommand();
+            
+            if (!restartSuccess) {
+                log.error("Redis 재시작 명령어 실행 실패");
+                return false;
+            }
+            
+            Thread.sleep(3000);
+            
+            for (int i = 0; i < 5; i++) {
+                boolean isHealthy = redisHealthService.forceHealthCheck();
+                if (isHealthy) {
+                    log.info("Redis 재시작 성공: 연결 확인 완료 (시도 횟수: {})", i + 1);
+                    return true;
+                }
+                if (i < 4) {
+                    Thread.sleep(2000);
+                }
+            }
+            
+            log.warn("Redis 재시작 후 연결 확인 실패");
+            return false;
+            
+        } catch (Exception e) {
+            log.error("Redis 재시작 시도 중 예외 발생", e);
+            return false;
+        }
+    }
+    
+    private boolean executeRestartCommand() {
+        try {
+            log.info("Redis 재시작 명령어 실행: {}", restartCommand);
+            
+            ProcessBuilder processBuilder;
+            String os = System.getProperty("os.name").toLowerCase();
+            
+            if (os.contains("win")) {
+                processBuilder = new ProcessBuilder("cmd", "/c", restartCommand);
+            } else {
+                processBuilder = new ProcessBuilder("sh", "-c", restartCommand);
+            }
+            
+            processBuilder.redirectErrorStream(true);
+            Process process = processBuilder.start();
+            
+            StringBuilder output = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append("\n");
+                    log.debug("Redis 재시작 명령어 출력: {}", line);
+                }
+            }
+            
+            boolean finished = process.waitFor(restartTimeoutSeconds, TimeUnit.SECONDS);
+            
+            if (!finished) {
+                log.error("Redis 재시작 명령어 실행 타임아웃 ({}초)", restartTimeoutSeconds);
+                process.destroyForcibly();
+                return false;
+            }
+            
+            int exitCode = process.exitValue();
+            if (exitCode == 0) {
+                log.info("Redis 재시작 명령어 실행 성공");
+                return true;
+            } else {
+                log.error("Redis 재시작 명령어 실행 실패: exitCode={}, output={}", exitCode, output);
+                return false;
+            }
+            
+        } catch (Exception e) {
+            log.error("Redis 재시작 명령어 실행 중 예외 발생", e);
+            return false;
+        }
+    }
+
+    public boolean testRedisConnection() {
+        try {
+            String result = redisTemplate.execute((RedisCallback<String>) connection -> {
+                return connection.ping();
+            });
+            
+            boolean isConnected = "PONG".equals(result);
+            
+            if (isConnected) {
+                log.info("Redis 연결 테스트 성공");
+                redisHealthService.setHealthy(true);
+            } else {
+                log.warn("Redis 연결 테스트 실패: PING 응답이 PONG이 아님");
+                redisHealthService.setHealthy(false);
+            }
+            
+            return isConnected;
+        } catch (Exception e) {
+            log.error("Redis 연결 테스트 중 예외 발생", e);
+            redisHealthService.setHealthy(false);
+            return false;
+        }
+    }
+
+    public boolean performHealthCheck() {
+        return redisHealthService.forceHealthCheck();
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/CashbackJpaAdapter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/CashbackJpaAdapter.java
@@ -49,3 +49,4 @@ public class CashbackJpaAdapter {
     }
 }
 
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/ExchangeRateJpaAdapter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/ExchangeRateJpaAdapter.java
@@ -26,3 +26,4 @@ public class ExchangeRateJpaAdapter {
     }
 }
 
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/PointJpaAdapter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/PointJpaAdapter.java
@@ -64,3 +64,4 @@ public class PointJpaAdapter {
     }
 }
 
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/UserTierHistoryJpaAdapter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/persistence/adapter/UserTierHistoryJpaAdapter.java
@@ -28,3 +28,4 @@ public class UserTierHistoryJpaAdapter {
     }
 }
 
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/retry/RetryPolicy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/payment/infrastructure/retry/RetryPolicy.java
@@ -57,3 +57,4 @@ public class RetryPolicy {
     }
 }
 
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/dto/admin/response/RedisStatusResponseDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/dto/admin/response/RedisStatusResponseDto.java
@@ -1,0 +1,28 @@
+package org.example.sharedprompts.dto.admin.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Redis 상태 응답 DTO
+ */
+@Getter
+@Builder
+public class RedisStatusResponseDto {
+    
+    /**
+     * Redis가 정상 상태인지 여부
+     */
+    private boolean healthy;
+    
+    /**
+     * Redis에 연결되어 있는지 여부
+     */
+    private boolean connected;
+    
+    /**
+     * 상태 메시지 (선택적)
+     */
+    private String message;
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/DiscordNotificationService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/DiscordNotificationService.java
@@ -1,0 +1,78 @@
+package org.example.sharedprompts.global.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.global.notification.dto.DiscordWebhookPayload;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordNotificationService {
+
+    private final RestTemplate restTemplate;
+    
+    @Value("${discord.webhook.url:}")
+    private String webhookUrl;
+    
+    @Value("${discord.webhook.enabled:false}")
+    private boolean enabled;
+
+    public void sendRedisDownNotification(String errorMessage, long consecutiveFailures) {
+        if (!enabled || webhookUrl == null || webhookUrl.isEmpty()) {
+            log.debug("Discord 알림이 비활성화되어 있거나 웹훅 URL이 설정되지 않았습니다.");
+            return;
+        }
+
+        try {
+            DiscordWebhookPayload payload = RedisNotificationEmbedBuilder.buildDownNotification(errorMessage, consecutiveFailures);
+            sendWebhook(payload);
+            log.info("Discord Redis 장애 알림 전송 완료");
+        } catch (Exception e) {
+            log.error("Discord Redis 장애 알림 전송 실패", e);
+        }
+    }
+
+    public void sendRedisRecoveryNotification(long downtimeDurationMs) {
+        if (!enabled || webhookUrl == null || webhookUrl.isEmpty()) {
+            log.debug("Discord 알림이 비활성화되어 있거나 웹훅 URL이 설정되지 않았습니다.");
+            return;
+        }
+
+        try {
+            DiscordWebhookPayload payload = RedisNotificationEmbedBuilder.buildRecoveryNotification(downtimeDurationMs);
+            sendWebhook(payload);
+            log.info("Discord Redis 복구 알림 전송 완료");
+        } catch (Exception e) {
+            log.error("Discord Redis 복구 알림 전송 실패", e);
+        }
+    }
+
+    private void sendWebhook(DiscordWebhookPayload payload) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            
+            HttpEntity<DiscordWebhookPayload> request = new HttpEntity<>(payload, headers);
+            
+            ResponseEntity<String> response = restTemplate.postForEntity(webhookUrl, request, String.class);
+            
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.debug("Discord 웹훅 전송 성공");
+            } else {
+                log.warn("Discord 웹훅 전송 실패: status={}, body={}", 
+                        response.getStatusCode(), response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Discord 웹훅 전송 중 예외 발생", e);
+            throw e;
+        }
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/DiscordNotificationService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/DiscordNotificationService.java
@@ -65,9 +65,6 @@ public class DiscordNotificationService {
             
             if (response.getStatusCode().is2xxSuccessful()) {
                 log.debug("Discord 웹훅 전송 성공");
-            } else {
-                log.warn("Discord 웹훅 전송 실패: status={}, body={}", 
-                        response.getStatusCode(), response.getBody());
             }
         } catch (Exception e) {
             log.error("Discord 웹훅 전송 중 예외 발생", e);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/RedisNotificationEmbedBuilder.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/RedisNotificationEmbedBuilder.java
@@ -8,17 +8,19 @@ import org.example.sharedprompts.global.util.DurationFormatter;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class RedisNotificationEmbedBuilder {
 
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final ZoneId TIMEZONE = ZoneId.of("Asia/Seoul");
     private static final int ERROR_MESSAGE_MAX_LENGTH = 1000;
     private static final String FOOTER_TEXT = "SharedPrompts Backend";
 
     public static DiscordWebhookPayload buildDownNotification(String errorMessage, long consecutiveFailures) {
-        String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
+        String timestamp = LocalDateTime.now(TIMEZONE).format(TIMESTAMP_FORMATTER);
         
         DiscordEmbed embed = DiscordEmbed.builder()
                 .title("🚨 Redis 장애 감지")
@@ -59,7 +61,7 @@ public class RedisNotificationEmbedBuilder {
     }
 
     public static DiscordWebhookPayload buildRecoveryNotification(long downtimeDurationMs) {
-        String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
+        String timestamp = LocalDateTime.now(TIMEZONE).format(TIMESTAMP_FORMATTER);
         String downtimeText = DurationFormatter.formatDowntime(downtimeDurationMs);
         
         DiscordEmbed embed = DiscordEmbed.builder()

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/RedisNotificationEmbedBuilder.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/RedisNotificationEmbedBuilder.java
@@ -14,6 +14,10 @@ import java.util.List;
 
 public class RedisNotificationEmbedBuilder {
 
+    private RedisNotificationEmbedBuilder() {
+        // 유틸리티 클래스이므로 인스턴스화 방지
+    }
+
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final ZoneId TIMEZONE = ZoneId.of("Asia/Seoul");
     private static final int ERROR_MESSAGE_MAX_LENGTH = 1000;

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/RedisNotificationEmbedBuilder.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/RedisNotificationEmbedBuilder.java
@@ -1,0 +1,103 @@
+package org.example.sharedprompts.global.notification;
+
+import org.example.sharedprompts.global.notification.dto.DiscordEmbed;
+import org.example.sharedprompts.global.notification.dto.DiscordEmbedField;
+import org.example.sharedprompts.global.notification.dto.DiscordEmbedFooter;
+import org.example.sharedprompts.global.notification.dto.DiscordWebhookPayload;
+import org.example.sharedprompts.global.util.DurationFormatter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class RedisNotificationEmbedBuilder {
+
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final int ERROR_MESSAGE_MAX_LENGTH = 1000;
+    private static final String FOOTER_TEXT = "SharedPrompts Backend";
+
+    public static DiscordWebhookPayload buildDownNotification(String errorMessage, long consecutiveFailures) {
+        String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
+        
+        DiscordEmbed embed = DiscordEmbed.builder()
+                .title("🚨 Redis 장애 감지")
+                .color(15158332)
+                .description("Redis 서버에 연결할 수 없거나 응답하지 않습니다.")
+                .fields(List.of(
+                        DiscordEmbedField.builder()
+                                .name("⏰ 감지 시간")
+                                .value(timestamp)
+                                .inline(true)
+                                .build(),
+                        DiscordEmbedField.builder()
+                                .name("❌ 연속 실패 횟수")
+                                .value(String.valueOf(consecutiveFailures))
+                                .inline(true)
+                                .build(),
+                        DiscordEmbedField.builder()
+                                .name("📝 오류 메시지")
+                                .value(formatErrorMessage(errorMessage))
+                                .inline(false)
+                                .build(),
+                        DiscordEmbedField.builder()
+                                .name("🔧 조치 방법")
+                                .value("Redis 서버 상태를 확인하고 재시작하세요. (Docker: `docker restart redis`, systemd: `systemctl restart redis`, managed Redis: 클라우드 콘솔에서 확인)")
+                                .inline(false)
+                                .build()
+                ))
+                .footer(DiscordEmbedFooter.builder()
+                        .text(FOOTER_TEXT)
+                        .build())
+                .timestamp(Instant.now().toString())
+                .build();
+
+        return DiscordWebhookPayload.builder()
+                .content("⚠️ **Redis 서버 장애 알림**")
+                .embeds(List.of(embed))
+                .build();
+    }
+
+    public static DiscordWebhookPayload buildRecoveryNotification(long downtimeDurationMs) {
+        String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
+        String downtimeText = DurationFormatter.formatDowntime(downtimeDurationMs);
+        
+        DiscordEmbed embed = DiscordEmbed.builder()
+                .title("✅ Redis 서버 복구 완료")
+                .color(3066993)
+                .description("Redis 서버가 정상적으로 복구되었습니다.")
+                .fields(List.of(
+                        DiscordEmbedField.builder()
+                                .name("⏰ 복구 시간")
+                                .value(timestamp)
+                                .inline(true)
+                                .build(),
+                        DiscordEmbedField.builder()
+                                .name("⏱️ 장애 지속 시간")
+                                .value(downtimeText)
+                                .inline(true)
+                                .build()
+                ))
+                .footer(DiscordEmbedFooter.builder()
+                        .text(FOOTER_TEXT)
+                        .build())
+                .timestamp(Instant.now().toString())
+                .build();
+
+        return DiscordWebhookPayload.builder()
+                .content("✅ **Redis 서버 복구 알림**")
+                .embeds(List.of(embed))
+                .build();
+    }
+
+    private static String formatErrorMessage(String errorMessage) {
+        if (errorMessage == null) {
+            return "연결 실패";
+        }
+        if (errorMessage.length() > ERROR_MESSAGE_MAX_LENGTH) {
+            return errorMessage.substring(0, ERROR_MESSAGE_MAX_LENGTH) + "...";
+        }
+        return errorMessage;
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordEmbed.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordEmbed.java
@@ -1,0 +1,20 @@
+package org.example.sharedprompts.global.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DiscordEmbed {
+    private String title;
+    private String description;
+    private Integer color;
+    private List<DiscordEmbedField> fields;
+    private DiscordEmbedFooter footer;
+    private String timestamp;
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordEmbedField.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordEmbedField.java
@@ -1,0 +1,15 @@
+package org.example.sharedprompts.global.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DiscordEmbedField {
+    private String name;
+    private String value;
+    private Boolean inline;
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordEmbedFooter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordEmbedFooter.java
@@ -1,0 +1,13 @@
+package org.example.sharedprompts.global.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DiscordEmbedFooter {
+    private String text;
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordWebhookPayload.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/notification/dto/DiscordWebhookPayload.java
@@ -1,0 +1,16 @@
+package org.example.sharedprompts.global.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DiscordWebhookPayload {
+    private String content;
+    private List<DiscordEmbed> embeds;
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/redis/RedisHealthService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/redis/RedisHealthService.java
@@ -174,7 +174,7 @@ public class RedisHealthService {
             adaptiveBackoffMs.set(0);
             downSinceTime.set(0);
         } else {
-            downSinceTime.set(System.currentTimeMillis());
+            downSinceTime.compareAndSet(0, System.currentTimeMillis());
         }
         lastCheckTime.set(System.currentTimeMillis());
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/redis/RedisHealthService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/redis/RedisHealthService.java
@@ -13,14 +13,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
-/**
- * Redis Health Check 서비스
- * 
- * Redis 연결 상태를 주기적으로 확인하고, 장애 상태를 추적합니다.
- * Circuit Breaker와 연동하여 Fail-Open 정책을 지원합니다.
- * 
- * 수정: 동시성 안전성 강화, Health Check 중복 호출 방지, race condition 제거
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -28,29 +20,19 @@ public class RedisHealthService {
 
     private final StringRedisTemplate redisTemplate;
     private final RedisHealthCheckProperties healthCheckProperties;
-    private volatile RedisMetrics redisMetrics; // 수정: volatile로 가시성 보장
+    private volatile RedisMetrics redisMetrics;
     
     private final AtomicBoolean isHealthy = new AtomicBoolean(true);
     private final AtomicLong lastCheckTime = new AtomicLong(0);
     private final AtomicBoolean healthGaugeRegistered = new AtomicBoolean(false);
     private final AtomicLong consecutiveFailures = new AtomicLong(0);
-    
-    // 수정: Adaptive backoff를 위한 변수 (volatile로 가시성 보장)
+    private final AtomicLong downSinceTime = new AtomicLong(0);
     private final AtomicLong adaptiveBackoffMs = new AtomicLong(0);
-    private static final long MIN_TTL_MS = 1000; // 최소 TTL: 1초
-    private static final long MAX_BACKOFF_MS = 30_000; // 최대 backoff: 30초
-    
-    // 수정: Health Check 중복 호출 방지를 위한 lock
+    private static final long MIN_TTL_MS = 1000;
+    private static final long MAX_BACKOFF_MS = 30_000;
     private final ReentrantLock healthCheckLock = new ReentrantLock();
     private volatile boolean isChecking = false;
     
-    /**
-     * RedisMetrics 설정 (선택적 의존성)
-     * 
-     * <p>순환 참조 방지를 위해 setter injection 사용
-     * 
-     * 수정: 동시성 안전성을 위해 synchronized 사용
-     */
     public synchronized void setRedisMetrics(RedisMetrics redisMetrics) {
         this.redisMetrics = redisMetrics;
         registerHealthGaugeIfPossible();
@@ -63,49 +45,16 @@ public class RedisHealthService {
         }
     }
 
-    /**
-     * ApplicationReadyEvent에서 초기화
-     * 
-     * <p>PostConstruct 대신 ApplicationReadyEvent를 사용하여 초기화 순서 안정화
-     * 모든 Bean이 준비된 후에 초기화되므로 순환 참조 문제를 방지합니다.
-     * 
-     * 수정: 초기화 실패 시에도 서비스 계속 동작
-     */
     @EventListener(ApplicationReadyEvent.class)
     public void init() {
         try {
-            // Health Status Gauge 등록
             registerHealthGaugeIfPossible();
         } catch (Exception e) {
-            // 수정: 초기화 실패해도 서비스는 계속 동작
             log.error("Redis Health Service 초기화 실패 (서비스는 계속 동작)", e);
         }
     }
     
-    /**
-     * Redis 연결 상태 확인
-     * 
-     * <p>Adaptive backoff 및 최소 TTL 보장으로 stale 데이터 최소화:
-     * <ul>
-     *   <li>정상 상태: 기본 interval 사용 (기본 5초)</li>
-     *   <li>장애 상태: adaptive backoff 적용 (최대 30초)</li>
-     *   <li>최소 TTL: 1초 (stale 데이터 최소화)</li>
-     *   <li>캐시 정확성: 최소 TTL과 adaptive backoff로 최신 상태 보장</li>
-     * </ul>
-     * 
-     * <p>캐시 정확성 보장:
-     * <ul>
-     *   <li>최소 TTL(1초) 이내에는 캐시된 결과 반환 (과도한 Health Check 방지)</li>
-     *   <li>최소 TTL 경과 후에는 adaptive backoff를 고려한 interval 적용</li>
-     *   <li>장애 상태일 때는 backoff를 증가시켜 Health Check 빈도 감소</li>
-     * </ul>
-     * 
-     * 수정: 동시성 안전성 강화, 중복 호출 방지
-     * 
-     * @return Redis가 정상 상태이면 true, 장애 상태이면 false
-     */
     public boolean isRedisHealthy() {
-        // Health Check가 비활성화된 경우 항상 정상으로 간주
         if (!healthCheckProperties.isEnabled()) {
             return true;
         }
@@ -113,65 +62,40 @@ public class RedisHealthService {
         long currentTime = System.currentTimeMillis();
         long lastCheck = lastCheckTime.get();
         
-        // 최소 TTL 보장: 마지막 체크 후 최소 1초는 경과해야 함
         if (currentTime - lastCheck < MIN_TTL_MS && lastCheck > 0) {
             return isHealthy.get();
         }
         
-        // Adaptive backoff 계산
         long effectiveInterval = calculateEffectiveInterval();
         
-        // 최근에 체크했고 아직 인터벌이 지나지 않았다면 캐시된 결과 반환
         if (currentTime - lastCheck < effectiveInterval && lastCheck > 0) {
             return isHealthy.get();
         }
         
-        // 실제 Health Check 수행
         return performHealthCheck();
     }
     
-    /**
-     * Adaptive backoff를 고려한 유효한 인터벌 계산
-     * 
-     * <p>장애 상태일 때는 backoff를 적용하여 Health Check 빈도를 줄입니다.
-     * 정상 상태일 때는 기본 interval을 사용합니다.
-     * 
-     * 수정: 동시성 안전성 보장 (AtomicLong 사용)
-     * 
-     * @return 유효한 인터벌 (밀리초)
-     */
     private long calculateEffectiveInterval() {
         long baseInterval = healthCheckProperties.getIntervalMs();
         long backoff = adaptiveBackoffMs.get();
         
         if (backoff > 0) {
-            // 장애 상태: base interval + backoff (최대 30초)
             return Math.min(baseInterval + backoff, MAX_BACKOFF_MS);
         }
         
-        // 정상 상태: base interval만 사용
         return baseInterval;
     }
     
-    /**
-     * 실제 Health Check 수행
-     * 
-     * 수정: 동시성 안전성 강화, 중복 호출 방지, race condition 제거
-     */
     private boolean performHealthCheck() {
-        // 수정: lock을 사용하여 중복 호출 방지
         if (!healthCheckLock.tryLock()) {
-            // 다른 스레드가 체크 중이면 캐시된 결과 반환
             return isHealthy.get();
         }
         
         try {
-            // 수정: 중복 체크 방지 플래그 설정
             isChecking = true;
             
             long startTime = System.currentTimeMillis();
             try {
-                // PING 명령으로 연결 상태 확인
                 String result = redisTemplate.execute((RedisCallback<String>) connection -> {
                     return connection.ping();
                 });
@@ -179,21 +103,19 @@ public class RedisHealthService {
                 long duration = System.currentTimeMillis() - startTime;
                 
                 if ("PONG".equals(result)) {
-                    // 정상 상태
                     consecutiveFailures.set(0);
                     isHealthy.set(true);
-                    adaptiveBackoffMs.set(0); // Backoff 초기화
+                    adaptiveBackoffMs.set(0);
+                    downSinceTime.set(0);
                     lastCheckTime.set(System.currentTimeMillis());
                     log.debug("Redis Health Check: 정상");
                     
-                    // 메트릭 기록 (null 체크)
                     if (redisMetrics != null) {
                         redisMetrics.recordHealthCheckDuration(duration);
                     }
                     
                     return true;
                 } else {
-                    // 비정상 응답
                     handleHealthCheckFailure();
                     if (redisMetrics != null) {
                         redisMetrics.recordHealthCheckDuration(duration);
@@ -201,12 +123,10 @@ public class RedisHealthService {
                     return false;
                 }
             } catch (Exception e) {
-                // 예외 발생 시 장애 처리
                 long duration = System.currentTimeMillis() - startTime;
                 handleHealthCheckFailure();
                 log.warn("Redis Health Check 실패", e);
                 
-                // 메트릭 기록 (null 체크)
                 if (redisMetrics != null) {
                     redisMetrics.recordHealthCheckDuration(duration);
                 }
@@ -214,99 +134,56 @@ public class RedisHealthService {
                 return false;
             }
         } finally {
-            // 수정: lock 해제 및 플래그 초기화
             isChecking = false;
             healthCheckLock.unlock();
         }
     }
     
-    /**
-     * Health Check 실패 처리
-     * 
-     * <p>Adaptive backoff 적용:
-     * - 연속 실패 횟수에 따라 backoff 시간 증가
-     * - 최대 30초까지 증가
-     * 
-     * <p>캐시 갱신 정책:
-     * - 첫 번째 실패 시 즉시 캐시를 unhealthy로 갱신하여 Fail-Open 정책이 즉시 적용되도록 함
-     * - 연속 실패 횟수는 로깅 및 backoff 계산에만 사용
-     * 
-     * 수정: 동시성 안전성 보장 (AtomicLong 사용)
-     * 수정: 첫 번째 실패 시 즉시 캐시 갱신하여 Fail-Open 정책 즉시 적용
-     */
     private void handleHealthCheckFailure() {
         long failures = consecutiveFailures.incrementAndGet();
         lastCheckTime.set(System.currentTimeMillis());
         
-        // Adaptive backoff 계산: 실패 횟수에 따라 지수적으로 증가
-        // 예: 3회 실패 → 1초, 6회 실패 → 2초, 9회 실패 → 4초, ...
         long maxFailures = Math.max(1, healthCheckProperties.getMaxConsecutiveFailures());
         long backoff = Math.min((failures / maxFailures) * 1000, MAX_BACKOFF_MS);
         adaptiveBackoffMs.set(backoff);
 
-        // 수정: 첫 번째 실패 시 즉시 캐시를 unhealthy로 갱신
-        // 이렇게 하면 RedisExecutor.executeRead()에서 getCachedHealthStatus()를 호출할 때
-        // 즉시 Fail-Open 정책이 적용되어 부정확한 캐시 상태로 인한 문제를 방지
         if (isHealthy.compareAndSet(true, false)) {
+            downSinceTime.set(System.currentTimeMillis());
             log.error("Redis 장애 감지: Health Check 실패 (연속 실패 횟수: {}, backoff: {}ms)", failures, backoff);
         } else if (failures >= maxFailures) {
-            // 이미 unhealthy 상태이지만, maxFailures에 도달한 경우 추가 로깅
             log.error("Redis 장애 지속: 연속 {}회 Health Check 실패 (backoff: {}ms)", failures, backoff);
         }
     }
     
-    /**
-     * 외부에서 Health Check 실패를 보고할 때 사용
-     * (예: DataAccessException 발생 시)
-     * 
-     * 수정: 동시성 안전성 보장
-     */
     public void reportFailure() {
         handleHealthCheckFailure();
     }
     
-    /**
-     * 강제로 Health Check 수행 (캐시 무시)
-     * 
-     * 수정: 동시성 안전성 보장
-     * 
-     * @return Redis가 정상 상태이면 true
-     */
     public boolean forceHealthCheck() {
         return performHealthCheck();
     }
     
-    /**
-     * 현재 Health 상태 반환 (캐시된 값)
-     * 
-     * 수정: 동시성 안전성 보장 (AtomicBoolean 사용)
-     * 
-     * @return 마지막 Health Check 결과
-     */
     public boolean getCachedHealthStatus() {
         return isHealthy.get();
     }
     
-    /**
-     * Health 상태를 강제로 설정 (복구 시 사용)
-     * 
-     * <p>테스트 환경에서 사용 가능:
-     * <ul>
-     *   <li>@MockBean으로 RedisHealthService를 모킹할 수 있음</li>
-     *   <li>setter 주입은 선택적이므로 테스트에서 생략 가능</li>
-     *   <li>이 메서드를 통해 테스트에서 Health 상태를 강제로 설정 가능</li>
-     * </ul>
-     * 
-     * 수정: 동시성 안전성 보장
-     * 
-     * @param healthy Health 상태 (true: 정상, false: 장애)
-     */
     public void setHealthy(boolean healthy) {
         isHealthy.set(healthy);
         if (healthy) {
             consecutiveFailures.set(0);
-            adaptiveBackoffMs.set(0); // Backoff 초기화
+            adaptiveBackoffMs.set(0);
+            downSinceTime.set(0);
+        } else {
+            downSinceTime.set(System.currentTimeMillis());
         }
         lastCheckTime.set(System.currentTimeMillis());
+    }
+    
+    public long getConsecutiveFailures() {
+        return consecutiveFailures.get();
+    }
+    
+    public long getDownSinceTime() {
+        return downSinceTime.get();
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/util/DurationFormatter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/util/DurationFormatter.java
@@ -1,6 +1,9 @@
 package org.example.sharedprompts.global.util;
 
 public class DurationFormatter {
+
+    private DurationFormatter() {
+    }
     
     public static String formatDowntime(long durationMs) {
         if (durationMs <= 0) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/global/util/DurationFormatter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/global/util/DurationFormatter.java
@@ -1,0 +1,26 @@
+package org.example.sharedprompts.global.util;
+
+public class DurationFormatter {
+    
+    public static String formatDowntime(long durationMs) {
+        if (durationMs <= 0) {
+            return "알 수 없음";
+        }
+        
+        long seconds = durationMs / 1000;
+        long minutes = seconds / 60;
+        long hours = minutes / 60;
+        long days = hours / 24;
+        
+        if (days > 0) {
+            return String.format("%d일 %d시간 %d분", days, hours % 24, minutes % 60);
+        } else if (hours > 0) {
+            return String.format("%d시간 %d분", hours, minutes % 60);
+        } else if (minutes > 0) {
+            return String.format("%d분 %d초", minutes, seconds % 60);
+        } else {
+            return String.format("%d초", seconds);
+        }
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/scheduler/redis/RedisHealthCheckScheduler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/scheduler/redis/RedisHealthCheckScheduler.java
@@ -21,7 +21,6 @@ public class RedisHealthCheckScheduler {
     private final AtomicBoolean previousHealthyStatus = new AtomicBoolean(true);
     private final AtomicLong lastNotificationTime = new AtomicLong(0);
     private static final long NOTIFICATION_COOLDOWN_MS = 60_000;
-    private final AtomicLong downSinceTime = new AtomicLong(0);
 
     @Scheduled(
             fixedDelayString = "${redis.health-check.fixed-delay:5000}",
@@ -34,7 +33,6 @@ public class RedisHealthCheckScheduler {
 
             if (!isHealthy) {
                 if (previousHealthy) {
-                    downSinceTime.set(System.currentTimeMillis());
                     sendRedisDownNotification();
                 }
             } else {
@@ -48,7 +46,6 @@ public class RedisHealthCheckScheduler {
             log.error("Redis Health Check 예외 발생", e);
 
             if (previousHealthyStatus.get()) {
-                downSinceTime.set(System.currentTimeMillis());
                 sendRedisDownNotification();
                 previousHealthyStatus.set(false);
             }
@@ -64,7 +61,6 @@ public class RedisHealthCheckScheduler {
         }
 
         try {
-            redisHealthService.reportFailure();
             long consecutiveFailures = redisHealthService.getConsecutiveFailures();
             long failureCount = Math.max(1, consecutiveFailures);
             
@@ -81,11 +77,10 @@ public class RedisHealthCheckScheduler {
 
     private void sendRedisRecoveryNotification() {
         try {
-            long downSince = downSinceTime.get();
+            long downSince = redisHealthService.getDownSinceTime();
             long downtimeDuration = 0;
             if (downSince > 0) {
                 downtimeDuration = System.currentTimeMillis() - downSince;
-                downSinceTime.set(0);
             }
             
             discordNotificationService.sendRedisRecoveryNotification(downtimeDuration);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/scheduler/redis/RedisHealthCheckScheduler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/scheduler/redis/RedisHealthCheckScheduler.java
@@ -2,57 +2,97 @@ package org.example.sharedprompts.scheduler.redis;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.global.notification.DiscordNotificationService;
 import org.example.sharedprompts.global.redis.RedisHealthService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * Redis Health Check 스케줄러
- * 
- * <p>주기적으로 Redis Health Check를 수행하여 장애를 조기에 감지합니다.
- * Health Check 결과는 RedisHealthService에 캐시되어,
- * Redis 호출 전에 사전 Fail-Open 정책을 적용하는 데 사용됩니다.
- * 
- * <p>스케줄 설정:
- * <ul>
- *   <li>실행 주기: 5초마다 (fixedDelay = 5000)</li>
- *   <li>초기 지연: 10초 (initialDelay = 10000)</li>
- * </ul>
- * 
- * <p>동작 방식:
- * <ol>
- *   <li>5초마다 RedisHealthService.isRedisHealthy() 호출</li>
- *   <li>Health Check 결과가 RedisHealthService에 캐시됨</li>
- *   <li>Redis 호출 시 캐시된 Health Check 결과를 사용하여 사전 Fail-Open 적용</li>
- * </ol>
- */
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisHealthCheckScheduler {
-    
+
     private final RedisHealthService redisHealthService;
-    
-    /**
-     * 주기적 Redis Health Check 수행
-     * 
-     * <p>5초마다 실행되며, Redis 연결 상태를 확인합니다.
-     * Health Check 결과는 RedisHealthService에 캐시되어
-     * Redis 호출 전에 사전 Fail-Open 정책을 적용하는 데 사용됩니다.
-     */
-    @Scheduled(fixedDelayString = "${redis.health-check.fixed-delay:5000}",
-                initialDelayString = "${redis.health-check.initial-delay:10000}") // 5초마다, 시작 후 10초 지연
+    private final DiscordNotificationService discordNotificationService;
+
+    private final AtomicBoolean previousHealthyStatus = new AtomicBoolean(true);
+    private final AtomicLong lastNotificationTime = new AtomicLong(0);
+    private static final long NOTIFICATION_COOLDOWN_MS = 60_000;
+    private final AtomicLong downSinceTime = new AtomicLong(0);
+
+    @Scheduled(
+            fixedDelayString = "${redis.health-check.fixed-delay:5000}",
+            initialDelayString = "${redis.health-check.initial-delay:10000}"
+    )
     public void performHealthCheck() {
         try {
             boolean isHealthy = redisHealthService.isRedisHealthy();
+            boolean previousHealthy = previousHealthyStatus.get();
+
             if (!isHealthy) {
-                log.warn("Redis Health Check: 장애 상태 감지");
+                if (previousHealthy) {
+                    downSinceTime.set(System.currentTimeMillis());
+                    sendRedisDownNotification();
+                }
             } else {
-                log.debug("Redis Health Check: 정상 상태");
+                if (!previousHealthy) {
+                    sendRedisRecoveryNotification();
+                }
             }
+
+            previousHealthyStatus.set(isHealthy);
         } catch (Exception e) {
-            log.error("Redis Health Check 수행 중 예외 발생", e);
+            log.error("Redis Health Check 예외 발생", e);
+
+            if (previousHealthyStatus.get()) {
+                downSinceTime.set(System.currentTimeMillis());
+                sendRedisDownNotification();
+                previousHealthyStatus.set(false);
+            }
+        }
+    }
+
+    private void sendRedisDownNotification() {
+        long now = System.currentTimeMillis();
+        long last = lastNotificationTime.get();
+
+        if (last > 0 && now - last < NOTIFICATION_COOLDOWN_MS) {
+            return;
+        }
+
+        try {
+            redisHealthService.reportFailure();
+            long consecutiveFailures = redisHealthService.getConsecutiveFailures();
+            long failureCount = Math.max(1, consecutiveFailures);
+            
+            discordNotificationService.sendRedisDownNotification(
+                    "Redis 서버에 연결할 수 없습니다. Health Check 실패.",
+                    failureCount
+            );
+            lastNotificationTime.set(now);
+            log.info("Redis 장애 알림 전송 (실패 횟수: {})", failureCount);
+        } catch (Exception e) {
+            log.error("Redis 장애 알림 전송 실패", e);
+        }
+    }
+
+    private void sendRedisRecoveryNotification() {
+        try {
+            long downSince = downSinceTime.get();
+            long downtimeDuration = 0;
+            if (downSince > 0) {
+                downtimeDuration = System.currentTimeMillis() - downSince;
+                downSinceTime.set(0);
+            }
+            
+            discordNotificationService.sendRedisRecoveryNotification(downtimeDuration);
+            lastNotificationTime.set(0);
+            log.info("Redis 복구 알림 전송 (장애 지속 시간: {}ms)", downtimeDuration);
+        } catch (Exception e) {
+            log.error("Redis 복구 알림 전송 실패", e);
         }
     }
 }
-

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/scheduler/redis/RedisHealthCheckScheduler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/scheduler/redis/RedisHealthCheckScheduler.java
@@ -28,6 +28,7 @@ public class RedisHealthCheckScheduler {
     )
     public void performHealthCheck() {
         try {
+            long currentDownSince = redisHealthService.getDownSinceTime();
             boolean isHealthy = redisHealthService.isRedisHealthy();
             boolean previousHealthy = previousHealthyStatus.get();
 
@@ -37,7 +38,7 @@ public class RedisHealthCheckScheduler {
                 }
             } else {
                 if (!previousHealthy) {
-                    sendRedisRecoveryNotification();
+                    sendRedisRecoveryNotification(currentDownSince);
                 }
             }
 
@@ -75,9 +76,8 @@ public class RedisHealthCheckScheduler {
         }
     }
 
-    private void sendRedisRecoveryNotification() {
+    private void sendRedisRecoveryNotification(long downSince) {
         try {
-            long downSince = redisHealthService.getDownSinceTime();
             long downtimeDuration = 0;
             if (downSince > 0) {
                 downtimeDuration = System.currentTimeMillis() - downSince;

--- a/sharedPrompts/src/main/resources/application.yml
+++ b/sharedPrompts/src/main/resources/application.yml
@@ -154,6 +154,30 @@ redis:
     enabled: ${REDIS_HEALTH_CHECK_ENABLED:true}
     interval-ms: ${REDIS_HEALTH_CHECK_INTERVAL_MS:5000}
     max-consecutive-failures: ${REDIS_HEALTH_CHECK_MAX_CONSECUTIVE_FAILURES:3}
+  # Redis 재시작 설정
+  restart:
+    # Redis 재시작 기능 활성화 여부 (보안상 기본값: false)
+    enabled: ${REDIS_RESTART_ENABLED:false}
+    # Redis 재시작 명령어
+    # 예시:
+    #   Linux (systemd): systemctl restart redis
+    #   Linux (service): service redis restart
+    #   Windows: net stop redis && net start redis
+    #   Docker: docker restart redis-container
+    command: ${REDIS_RESTART_COMMAND:}
+    # 재시작 명령어 실행 타임아웃 (초)
+    timeout-seconds: ${REDIS_RESTART_TIMEOUT_SECONDS:30}
+
+# =========================
+# Discord 웹훅 알림 설정
+# =========================
+discord:
+  webhook:
+    # Discord 웹훅 URL (선택적)
+    # Discord 채널 설정 > 연동 > 웹후크 > 새 웹후크 만들기에서 URL을 복사하여 설정
+    url: ${DISCORD_WEBHOOK_URL:}
+    # Discord 알림 활성화 여부
+    enabled: ${DISCORD_WEBHOOK_ENABLED:false}
 
 # =========================
 # ShedLock 설정


### PR DESCRIPTION
- Discord 웹훅을 통한 Redis 장애/복구 알림 기능 구현
  - RedisHealthCheckScheduler에 알림 로직 통합
  - 장애 감지 시 즉시 알림 전송 (쿨다운 60초)
  - 복구 시 장애 지속 시간 포함 알림 전송

- 관리자용 Redis 관리 API 추가
  - GET /admin/redis/status: Redis 상태 조회
  - POST /admin/redis/restart: Redis 재시작
  - POST /admin/redis/test-connection: 연결 테스트
  - POST /admin/redis/health-check: 헬스 체크 수행

- RedisHealthService 개선
  - 장애 발생 시점 추적을 위한 downSinceTime 필드 추가
  - getConsecutiveFailures(), getDownSinceTime() 메서드 추가
  - 불필요한 주석 제거 및 코드 정리

- DurationFormatter 유틸리티 추가
  - 밀리초를 읽기 쉬운 형식으로 변환 (예: 1시간 30분 15초)

- application.yml 설정 추가
  - Discord 웹훅 URL 및 활성화 설정
  - Redis 재시작 명령어 및 타임아웃 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자용 Redis 관리 기능 추가: 상태 조회, 재시작, 연결 테스트, 헬스 체크 API 제공
  * Redis 장애 및 복구 시 Discord 알림 자동 전송 기능 추가(다운/복구 메시지 포함, 한글 시간/기간 포맷 적용)
  * Redis 상태 변화를 감지하는 주기 검사 및 알림 쿨다운 로직 추가

* **구성**
  * Discord 웹훅 설정 및 Redis 재시작 옵션(활성화, 명령, 타임아웃) 추가
  * API 컬렉션에 Redis 관리 엔드포인트 추가 (Postman)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->