### PR TITLE
refactor(production): P1 중기 개선 사항 완료 및 코드 구조 정리

### DIFF
--- a/sharedPrompts/COMMIT_MESSAGE.md
+++ b/sharedPrompts/COMMIT_MESSAGE.md
@@ -1,76 +1,74 @@
-refactor(production): 코드 품질 개선 및 아키텍처 정리
+refactor(production): P1 중기 개선 사항 완료 및 코드 구조 정리
 
 ## 주요 변경사항
 
-### 1. YAML 설정 구조 개선
-- `application.yml`: artifact 키의 YAML 계층 구조 명확화
-  - 주석 들여쓰기 수정 및 섹션 헤더 추가
-  - `artifact:`를 루트 레벨로 명확히 표시
+### 1. P1 중기 개선 사항 완료
 
-### 2. 예외 처리 일관성 개선
-- `ArtifactAccessServiceImpl`: RuntimeException → BaseException 변경
-  - `ModuleErrorCode.STORAGE_ERROR` 사용으로 일관된 예외 처리
-  - 원인 예외(cause) 포함하여 예외 체인 유지
+#### PDF 변환 개선
+- `PdfFormatConverter`: Markdown → HTML → PDF 파이프라인 통합
+  - Markdown 콘텐츠 자동 감지 및 변환
+  - FlexMark를 사용한 Markdown 파싱 (제목, 리스트, 코드 블록, 테이블 등 지원)
+  - OpenHTMLToPDF를 사용한 HTML → PDF 변환
+  - CSS 스타일링 지원
+  - 일반 텍스트도 HTML로 감싸서 PDF 변환 지원
 
-### 3. 리소스 관리 개선
-- `S3Config`: S3Presigner에 `@Bean(destroyMethod = "close")` 명시
-  - 명시적 리소스 정리로 메모리 누수 방지
+#### StorageStrategy 인터페이스 확장
+- `read()`, `exists()`, `delete()`, `generateAccessUrl()` 메서드 구현
+- `S3StorageStrategy`, `LocalStorageStrategy` 모두 지원
 
-### 4. 코드 리팩토링
-- `ArtifactDtoMapper`:
-  - private 생성자 추가 (유틸리티 클래스 인스턴스화 방지)
-  - if-else 체인을 switch 표현식으로 변경
-  - enum 값 추가 시 컴파일 타임 누락 감지 가능
+#### ArtifactHandler 전략 패턴
+- `ArtifactHandlerRegistry`로 타입별 Handler 관리
+- `TextArtifactHandler`, `FileArtifactHandler`, `ImageArtifactHandler` 구현
 
-- `ProductionResultApplicationService`:
-  - 중복된 Job 조회 및 소유권 검증 로직을 `getJobOrThrow()` 헬퍼 메서드로 추출
-  - `retryJob()`에 Job 상태 검증 추가 (FAILED/PARSE_FAILED만 retry 가능)
+### 2. 코드 구조 정리
 
-### 5. 인터페이스 분리 원칙 적용
-- `ArtifactDto` 구조 개선:
-  - `FileBasedArtifactDto` sealed interface 추가
-  - `TextArtifactDto`에서 불필요한 파일 메타데이터 필드 제거
-  - `ImageArtifactDto`, `FileArtifactDto`는 `FileBasedArtifactDto` 구현
+#### 폴더 구조 개선
+- PDF 관련 코드를 `format/pdf/` 서브폴더로 분리
+  - `HtmlToPdfConverter.java`
+  - `OpenHtmlToPdfConverterImpl.java`
+  - `PdfCssProvider.java`
+  - `DefaultPdfCssProvider.java`
 
-### 6. 환경별 구현체 분리
-- `LocalArtifactAccessServiceImpl` 추가:
-  - LOCAL 환경용 fallback 구현체
-  - `@ConditionalOnProperty(matchIfMissing = true)`로 기본값 지원
-  - 파일 경로를 그대로 반환 (Presigned URL 불필요)
+- Markdown 관련 코드를 `format/markdown/` 서브폴더로 분리
+  - `MarkdownToHtmlConverter.java`
+  - `FlexMarkMarkdownToHtmlConverter.java`
 
-### 7. TTL 일관성 개선
-- `ArtifactAccessServiceImpl`:
-  - 단일 TTL 설정값에서 Presigned URL TTL과 캐시 TTL 도출
-  - 캐시 TTL을 Presigned URL TTL보다 짧게 설정하여 만료된 URL 반환 방지
-  - `Math.max(ttlSeconds - 30, ttlSeconds / 2)` 공식 적용
+#### 주석 최소화
+- 불필요한 JavaDoc 주석 제거
+- 코드 자체로 의도가 명확하도록 정리
+- `StorageStrategy`, `ArtifactHandler` 인터페이스 주석 제거
 
-### 8. 테스트 코드 수정
-- `ProductionResponseDtoTest`:
-  - `ProductionResponseDto.from()` → `ProductionResponseDtoMapper.toDto()` 변경
-  - record 접근자 메서드 수정 (getStatus() → status())
-  - `testProcessingStatus`: completedAt을 null로 변경하여 비즈니스 로직 일관성 개선
+### 3. 의존성 업데이트
+- OpenHTMLToPDF 버전 업그레이드: `1.1.24` → `1.1.37`
+- 패키지 경로 변경: `com.openhtmltopdf` → `io.github.openhtmltopdf`
 
 ## 변경된 파일
 
 ### 신규 생성
-- `LocalArtifactAccessServiceImpl.java`
-- `FileBasedArtifactDto.java`
+- `format/pdf/HtmlToPdfConverter.java`
+- `format/pdf/OpenHtmlToPdfConverterImpl.java`
+- `format/pdf/PdfCssProvider.java`
+- `format/pdf/DefaultPdfCssProvider.java`
+- `format/markdown/MarkdownToHtmlConverter.java`
+- `format/markdown/FlexMarkMarkdownToHtmlConverter.java`
 
 ### 수정
-- `application.yml` (artifact 섹션 구조 개선)
-- `ArtifactAccessServiceImpl.java` (예외 처리, TTL 일관성)
-- `S3Config.java` (destroyMethod 명시)
-- `ArtifactDtoMapper.java` (private 생성자, switch 표현식)
-- `ProductionResultApplicationService.java` (중복 제거, 상태 검증)
-- `ArtifactDto.java` (인터페이스 분리)
-- `TextArtifactDto.java` (불필요한 필드 제거)
-- `ImageArtifactDto.java` (FileBasedArtifactDto 구현)
-- `FileArtifactDto.java` (FileBasedArtifactDto 구현)
-- `ProductionResponseDtoTest.java` (테스트 코드 수정)
+- `PdfFormatConverter.java` (Markdown → HTML → PDF 파이프라인 통합)
+- `StorageStrategy.java` (주석 제거)
+- `ArtifactHandler.java` (주석 제거)
+- `LocalStorageStrategy.java` (주석 제거)
+- `build.gradle` (OpenHTMLToPDF 의존성 업데이트)
+
+### 삭제
+- `format/HtmlToPdfConverter.java` (pdf 서브폴더로 이동)
+- `format/OpenHtmlToPdfConverterImpl.java` (pdf 서브폴더로 이동)
+- `format/PdfCssProvider.java` (pdf 서브폴더로 이동)
+- `format/DefaultPdfCssProvider.java` (pdf 서브폴더로 이동)
+- `format/MarkdownToHtmlConverter.java` (markdown 서브폴더로 이동)
+- `format/FlexMarkMarkdownToHtmlConverter.java` (markdown 서브폴더로 이동)
 
 ## 효과
-- 코드 품질 향상: 중복 제거, 일관성 개선
-- 타입 안전성 강화: sealed interface 활용
-- 환경별 지원: LOCAL/S3 환경 모두 정상 동작
-- 리소스 관리 개선: 명시적 정리로 메모리 누수 방지
-- 테스트 신뢰성 향상: 비즈니스 로직 반영
+- 코드 구조 명확화: PDF/Markdown 관련 코드가 논리적으로 그룹화됨
+- 확장성 향상: 새로운 변환 타입 추가 시 서브폴더 구조로 관리 용이
+- 코드 가독성 개선: 불필요한 주석 제거로 핵심 로직에 집중
+- PDF 변환 품질 향상: Markdown 구조 완벽 지원 및 CSS 스타일링 적용

--- a/sharedPrompts/COMMIT_MESSAGE.md
+++ b/sharedPrompts/COMMIT_MESSAGE.md
@@ -1,74 +1,32 @@
-refactor(production): P1 중기 개선 사항 완료 및 코드 구조 정리
+fix(production): 코드 리뷰 2차 피드백 반영 - 보안/안전성 추가 개선
 
 ## 주요 변경사항
 
-### 1. P1 중기 개선 사항 완료
+### 1. 보안 개선
 
-#### PDF 변환 개선
-- `PdfFormatConverter`: Markdown → HTML → PDF 파이프라인 통합
-  - Markdown 콘텐츠 자동 감지 및 변환
-  - FlexMark를 사용한 Markdown 파싱 (제목, 리스트, 코드 블록, 테이블 등 지원)
-  - OpenHTMLToPDF를 사용한 HTML → PDF 변환
-  - CSS 스타일링 지원
-  - 일반 텍스트도 HTML로 감싸서 PDF 변환 지원
+#### LocalStorageStrategy
+- store() 메서드 Path Traversal 취약점 수정: fileName에 `../` 포함 시 basePath 외부 쓰기 방지
+- validateWithinBasePath() 헬퍼 메서드 추가 (store 전용 경로 검증)
+- generateAccessUrl()에 운영 환경 사용 경고 로그 추가 (내부 파일시스템 경로 노출 방지)
 
-#### StorageStrategy 인터페이스 확장
-- `read()`, `exists()`, `delete()`, `generateAccessUrl()` 메서드 구현
-- `S3StorageStrategy`, `LocalStorageStrategy` 모두 지원
+### 2. 버그 수정
 
-#### ArtifactHandler 전략 패턴
-- `ArtifactHandlerRegistry`로 타입별 Handler 관리
-- `TextArtifactHandler`, `FileArtifactHandler`, `ImageArtifactHandler` 구현
+#### TextArtifactHandler
+- createDetail() 오버라이드 추가: TEXT 아티팩트의 content 필드가 null로 남는 문제 해결
+- storageStrategy.read()로 파일 내용을 읽어 INLINE_TEXT로 저장
 
-### 2. 코드 구조 정리
+#### ProductionArtifactService
+- ZoneId.systemDefault() → ZoneId.of("Asia/Seoul")로 변경 (환경별 시간대 차이 제거)
+- job.getCreatedAt() null 안전성 추가 (NPE 방지)
 
-#### 폴더 구조 개선
-- PDF 관련 코드를 `format/pdf/` 서브폴더로 분리
-  - `HtmlToPdfConverter.java`
-  - `OpenHtmlToPdfConverterImpl.java`
-  - `PdfCssProvider.java`
-  - `DefaultPdfCssProvider.java`
+### 3. 코드 정리
 
-- Markdown 관련 코드를 `format/markdown/` 서브폴더로 분리
-  - `MarkdownToHtmlConverter.java`
-  - `FlexMarkMarkdownToHtmlConverter.java`
-
-#### 주석 최소화
-- 불필요한 JavaDoc 주석 제거
-- 코드 자체로 의도가 명확하도록 정리
-- `StorageStrategy`, `ArtifactHandler` 인터페이스 주석 제거
-
-### 3. 의존성 업데이트
-- OpenHTMLToPDF 버전 업그레이드: `1.1.24` → `1.1.37`
-- 패키지 경로 변경: `com.openhtmltopdf` → `io.github.openhtmltopdf`
+#### ArtifactHandler 인터페이스
+- createDetail()에서 사용되지 않는 JobEntity job 파라미터 제거
 
 ## 변경된 파일
 
-### 신규 생성
-- `format/pdf/HtmlToPdfConverter.java`
-- `format/pdf/OpenHtmlToPdfConverterImpl.java`
-- `format/pdf/PdfCssProvider.java`
-- `format/pdf/DefaultPdfCssProvider.java`
-- `format/markdown/MarkdownToHtmlConverter.java`
-- `format/markdown/FlexMarkMarkdownToHtmlConverter.java`
-
-### 수정
-- `PdfFormatConverter.java` (Markdown → HTML → PDF 파이프라인 통합)
-- `StorageStrategy.java` (주석 제거)
-- `ArtifactHandler.java` (주석 제거)
-- `LocalStorageStrategy.java` (주석 제거)
-- `build.gradle` (OpenHTMLToPDF 의존성 업데이트)
-
-### 삭제
-- `format/HtmlToPdfConverter.java` (pdf 서브폴더로 이동)
-- `format/OpenHtmlToPdfConverterImpl.java` (pdf 서브폴더로 이동)
-- `format/PdfCssProvider.java` (pdf 서브폴더로 이동)
-- `format/DefaultPdfCssProvider.java` (pdf 서브폴더로 이동)
-- `format/MarkdownToHtmlConverter.java` (markdown 서브폴더로 이동)
-- `format/FlexMarkMarkdownToHtmlConverter.java` (markdown 서브폴더로 이동)
-
-## 효과
-- 코드 구조 명확화: PDF/Markdown 관련 코드가 논리적으로 그룹화됨
-- 확장성 향상: 새로운 변환 타입 추가 시 서브폴더 구조로 관리 용이
-- 코드 가독성 개선: 불필요한 주석 제거로 핵심 로직에 집중
-- PDF 변환 품질 향상: Markdown 구조 완벽 지원 및 CSS 스타일링 적용
+- `LocalStorageStrategy.java` - store() 경로 검증 추가, generateAccessUrl() 경고 로그
+- `ArtifactHandler.java` - createDetail() 미사용 job 파라미터 제거
+- `TextArtifactHandler.java` - createDetail() 오버라이드로 content 설정
+- `ProductionArtifactService.java` - 명시적 타임존 + null 안전성 + 호출부 파라미터 수정

--- a/sharedPrompts/Postman_Collection.json
+++ b/sharedPrompts/Postman_Collection.json
@@ -1741,56 +1741,6 @@
       "name": "Production",
       "item": [
         {
-          "name": "프롬프트 생산 실행",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"command\": {\n    \"command_type\": \"BLOG\",\n    \"title\": \"블로그 제목\",\n    \"tags\": [\"태그1\", \"태그2\"]\n  },\n  \"user_input\": {\n    \"input\": \"사용자 입력 내용\"\n  }\n}"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/prompts/1/production",
-              "host": ["{{baseUrl}}"],
-              "path": ["prompts", "1", "production"]
-            }
-          }
-        },
-        {
-          "name": "프롬프트 생산 실행 (EMAIL)",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Authorization",
-                "value": "Bearer {{accessToken}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"command\": {\n    \"command_type\": \"EMAIL\",\n    \"subject\": \"이메일 제목\",\n    \"recipient\": \"recipient@example.com\"\n  },\n  \"user_input\": {\n    \"input\": \"사용자 입력 내용\"\n  }\n}"
-            },
-            "url": {
-              "raw": "{{baseUrl}}/prompts/1/production",
-              "host": ["{{baseUrl}}"],
-              "path": ["prompts", "1", "production"]
-            }
-          }
-        },
-        {
           "name": "프롬프트 생산 실행 (TEXT)",
           "request": {
             "method": "POST",
@@ -1806,12 +1756,12 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"command\": {\n    \"command_type\": \"TEXT\",\n    \"file_name\": \"output.txt\",\n    \"format\": \"plain\"\n  },\n  \"user_input\": {\n    \"input\": \"사용자 입력 내용\"\n  }\n}"
+              "raw": "{\n  \"fileName\": \"output.txt\",\n  \"format\": \"plain\",\n  \"userInput\": \"사용자 입력 내용\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/prompts/1/production",
+              "raw": "{{baseUrl}}/prompts/1/production/text",
               "host": ["{{baseUrl}}"],
-              "path": ["prompts", "1", "production"]
+              "path": ["prompts", "1", "production", "text"]
             }
           }
         },
@@ -1831,12 +1781,87 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"command\": {\n    \"command_type\": \"IMAGE\",\n    \"prompt\": \"이미지 생성 프롬프트\",\n    \"width\": 1024,\n    \"height\": 768\n  },\n  \"user_input\": {\n    \"input\": \"사용자 입력 내용\"\n  }\n}"
+              "raw": "{\n  \"prompt\": \"이미지 생성 프롬프트\",\n  \"width\": 1024,\n  \"height\": 768,\n  \"userInput\": \"사용자 입력 내용\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/prompts/1/production",
+              "raw": "{{baseUrl}}/prompts/1/production/image",
               "host": ["{{baseUrl}}"],
-              "path": ["prompts", "1", "production"]
+              "path": ["prompts", "1", "production", "image"]
+            }
+          }
+        },
+        {
+          "name": "프롬프트 생산 실행 (EMAIL)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"subject\": \"이메일 제목\",\n  \"recipient\": \"recipient@example.com\",\n  \"userInput\": \"사용자 입력 내용\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/prompts/1/production/email",
+              "host": ["{{baseUrl}}"],
+              "path": ["prompts", "1", "production", "email"]
+            }
+          }
+        },
+        {
+          "name": "프롬프트 생산 실행 (BLOG)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"블로그 제목\",\n  \"tags\": [\"태그1\", \"태그2\"],\n  \"userInput\": \"사용자 입력 내용\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/prompts/1/production/blog",
+              "host": ["{{baseUrl}}"],
+              "path": ["prompts", "1", "production", "blog"]
+            }
+          }
+        },
+        {
+          "name": "프롬프트 생산 실행 (DOCUMENT)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fileName\": \"document.pdf\",\n  \"format\": \"pdf\",\n  \"userInput\": \"사용자 입력 내용\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/prompts/1/production/document",
+              "host": ["{{baseUrl}}"],
+              "path": ["prompts", "1", "production", "document"]
             }
           }
         },
@@ -1854,6 +1879,40 @@
               "raw": "{{baseUrl}}/production/1",
               "host": ["{{baseUrl}}"],
               "path": ["production", "1"]
+            }
+          }
+        },
+        {
+          "name": "작업 상태 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/jobs/job-id-123",
+              "host": ["{{baseUrl}}"],
+              "path": ["jobs", "job-id-123"]
+            }
+          }
+        },
+        {
+          "name": "작업 재시도",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/jobs/job-id-123/retry",
+              "host": ["{{baseUrl}}"],
+              "path": ["jobs", "job-id-123", "retry"]
             }
           }
         }
@@ -2727,6 +2786,244 @@
                   "raw": "{{baseUrl}}/admin/redis/health-check",
                   "host": ["{{baseUrl}}"],
                   "path": ["admin", "redis", "health-check"]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "포인트 관리",
+          "item": [
+            {
+              "name": "사용자 포인트 잔액 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/points/users/1/balance",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "points", "users", "1", "balance"]
+                }
+              }
+            },
+            {
+              "name": "사용자 포인트 내역 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/points/users/1/history?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "points", "users", "1", "history"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "사용자 포인트 차감",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"amount\": 1000,\n  \"description\": \"관리자 요청\"\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/admin/points/users/1/use",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "points", "users", "1", "use"]
+                }
+              }
+            },
+            {
+              "name": "결제별 포인트 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/points/payments/1?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "points", "payments", "1"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "캐시백 관리",
+          "item": [
+            {
+              "name": "사용자 캐시백 내역 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/cashbacks/users/1/history?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "cashbacks", "users", "1", "history"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "사용자 미지급 캐시백 총액 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/cashbacks/users/1/unpaid-total",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "cashbacks", "users", "1", "unpaid-total"]
+                }
+              }
+            },
+            {
+              "name": "사용자 미지급 캐시백 목록 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/cashbacks/users/1/unpaid?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "cashbacks", "users", "1", "unpaid"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "전체 미지급 캐시백 총액 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/cashbacks/unpaid-total",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "cashbacks", "unpaid-total"]
+                }
+              }
+            },
+            {
+              "name": "전체 미지급 캐시백 목록 조회",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/cashbacks/unpaid?page=0&size=20",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "cashbacks", "unpaid"],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "0"
+                    },
+                    {
+                      "key": "size",
+                      "value": "20"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "캐시백 지급",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{accessToken}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/admin/cashbacks/1/pay",
+                  "host": ["{{baseUrl}}"],
+                  "path": ["admin", "cashbacks", "1", "pay"]
                 }
               }
             }

--- a/sharedPrompts/build.gradle
+++ b/sharedPrompts/build.gradle
@@ -98,8 +98,16 @@ dependencies {
 	// Excel (Apache POI)
 	implementation 'org.apache.poi:poi-ooxml:5.2.5'
 
-	// PDF (OpenPDF)
+	// PDF (OpenPDF - legacy)
 	implementation 'com.github.librepdf:openpdf:1.3.30'
+
+	// Markdown → HTML (FlexMark)
+	implementation 'com.vladsch.flexmark:flexmark-all:0.64.8'
+
+	// HTML → PDF (OpenHTMLToPDF)
+	implementation 'io.github.openhtmltopdf:openhtmltopdf-core:1.1.37'
+	implementation 'io.github.openhtmltopdf:openhtmltopdf-pdfbox:1.1.37'
+	implementation 'io.github.openhtmltopdf:openhtmltopdf-slf4j:1.1.37'
 
 	// Testing
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/sharedPrompts/build.gradle
+++ b/sharedPrompts/build.gradle
@@ -98,11 +98,11 @@ dependencies {
 	// Excel (Apache POI)
 	implementation 'org.apache.poi:poi-ooxml:5.2.5'
 
-	// PDF (OpenPDF - legacy)
-	implementation 'com.github.librepdf:openpdf:1.3.30'
-
 	// Markdown → HTML (FlexMark)
-	implementation 'com.vladsch.flexmark:flexmark-all:0.64.8'
+	implementation 'com.vladsch.flexmark:flexmark:0.64.8'
+	implementation 'com.vladsch.flexmark:flexmark-ext-tables:0.64.8'
+	implementation 'com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:0.64.8'
+	implementation 'com.vladsch.flexmark:flexmark-ext-autolink:0.64.8'
 
 	// HTML → PDF (OpenHTMLToPDF)
 	implementation 'io.github.openhtmltopdf:openhtmltopdf-core:1.1.37'

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/application/ProductionResultApplicationService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/application/ProductionResultApplicationService.java
@@ -8,7 +8,7 @@ import org.example.sharedprompts.module.domain.production.model.job.JobStatus;
 import org.example.sharedprompts.module.domain.production.repository.production.ProductionArtifactRepository;
 import org.example.sharedprompts.module.domain.production.service.job.process.recovery.ProcessJobRecoveryService;
 import org.example.sharedprompts.module.domain.production.service.job.queue.JobQueueService;
-import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
+import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandlerRegistry;
 import org.example.sharedprompts.module.dto.response.production.JobResponseDto;
 import org.example.sharedprompts.module.dto.response.production.ProductionResponseDto;
 import org.example.sharedprompts.module.dto.response.production.ProductionResponseDtoMapper;
@@ -25,7 +25,7 @@ public class ProductionResultApplicationService {
     private final ProductionArtifactRepository productionArtifactRepository;
     private final JobQueueService jobQueueService;
     private final ProcessJobRecoveryService processJobRecoveryService;
-    private final ArtifactAccessService artifactAccessService;
+    private final ArtifactHandlerRegistry artifactHandlerRegistry;
 
     private Job getJobOrThrow(String jobId, Long userId) {
         Job job = jobQueueService.getJob(jobId);
@@ -51,7 +51,7 @@ public class ProductionResultApplicationService {
             throw new BaseException(ModuleErrorCode.PRODUCTION_FORBIDDEN);
         }
         
-        return ProductionResponseDtoMapper.toDto(artifact, artifactAccessService);
+        return ProductionResponseDtoMapper.toDto(artifact, artifactHandlerRegistry);
     }
 
     @Transactional(readOnly = true)

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandler.java
@@ -4,17 +4,27 @@ import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
 import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
+import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
 import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
 
 public interface ArtifactHandler {
 
     ArtifactType getSupportedType();
 
-    ProductionArtifactDetailEntity createDetail(
+    default ProductionArtifactDetailEntity createDetail(
             JobEntity job,
             String filePath,
             StorageStrategy storageStrategy
-    );
+    ) {
+        return ProductionArtifactDetailEntity.builder()
+                .artifactType(getSupportedType())
+                .storageType(ArtifactMetadataHelper.determineStorageFormat(filePath))
+                .filePath(filePath)
+                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
+                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
+                .storageLocation(storageStrategy.getStorageType().name())
+                .build();
+    }
 
     ArtifactDto toDto(ProductionArtifactDetailEntity detail);
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandler.java
@@ -1,0 +1,20 @@
+package org.example.sharedprompts.module.domain.production.service.artifact;
+
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
+import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
+import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
+
+public interface ArtifactHandler {
+
+    ArtifactType getSupportedType();
+
+    ProductionArtifactDetailEntity createDetail(
+            JobEntity job,
+            String filePath,
+            StorageStrategy storageStrategy
+    );
+
+    ArtifactDto toDto(ProductionArtifactDetailEntity detail);
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandler.java
@@ -1,6 +1,5 @@
 package org.example.sharedprompts.module.domain.production.service.artifact;
 
-import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
 import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
@@ -12,7 +11,6 @@ public interface ArtifactHandler {
     ArtifactType getSupportedType();
 
     default ProductionArtifactDetailEntity createDetail(
-            JobEntity job,
             String filePath,
             StorageStrategy storageStrategy
     ) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandlerRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandlerRegistry.java
@@ -1,0 +1,32 @@
+package org.example.sharedprompts.module.domain.production.service.artifact;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Slf4j
+public class ArtifactHandlerRegistry {
+
+    private final Map<ArtifactType, ArtifactHandler> handlerMap = new ConcurrentHashMap<>();
+
+    public ArtifactHandlerRegistry(List<ArtifactHandler> handlers) {
+        for (ArtifactHandler handler : handlers) {
+            handlerMap.put(handler.getSupportedType(), handler);
+            log.info("Registered ArtifactHandler: {} for type: {}",
+                    handler.getClass().getSimpleName(), handler.getSupportedType());
+        }
+    }
+
+    public ArtifactHandler getHandler(ArtifactType type) {
+        ArtifactHandler handler = handlerMap.get(type);
+        if (handler == null) {
+            throw new IllegalArgumentException("No ArtifactHandler found for type: " + type);
+        }
+        return handler;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandlerRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ArtifactHandlerRegistry.java
@@ -4,22 +4,31 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 @Slf4j
 public class ArtifactHandlerRegistry {
 
-    private final Map<ArtifactType, ArtifactHandler> handlerMap = new ConcurrentHashMap<>();
+    private final Map<ArtifactType, ArtifactHandler> handlerMap;
 
     public ArtifactHandlerRegistry(List<ArtifactHandler> handlers) {
+        Map<ArtifactType, ArtifactHandler> map = new HashMap<>();
         for (ArtifactHandler handler : handlers) {
-            handlerMap.put(handler.getSupportedType(), handler);
+            ArtifactHandler existing = map.put(handler.getSupportedType(), handler);
+            if (existing != null) {
+                log.warn("Duplicate ArtifactHandler for type: {}. {} replaced by {}",
+                        handler.getSupportedType(),
+                        existing.getClass().getSimpleName(),
+                        handler.getClass().getSimpleName());
+            }
             log.info("Registered ArtifactHandler: {} for type: {}",
                     handler.getClass().getSimpleName(), handler.getSupportedType());
         }
+        this.handlerMap = Collections.unmodifiableMap(map);
     }
 
     public ArtifactHandler getHandler(ArtifactType type) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/FileArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/FileArtifactHandler.java
@@ -1,0 +1,54 @@
+package org.example.sharedprompts.module.domain.production.service.artifact;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
+import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
+import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
+import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
+import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
+import org.example.sharedprompts.module.dto.response.production.FileArtifactDto;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FileArtifactHandler implements ArtifactHandler {
+
+    private final ArtifactAccessService artifactAccessService;
+
+    @Override
+    public ArtifactType getSupportedType() {
+        return ArtifactType.FILE;
+    }
+
+    @Override
+    public ProductionArtifactDetailEntity createDetail(
+            JobEntity job, String filePath, StorageStrategy storageStrategy) {
+
+        return ProductionArtifactDetailEntity.builder()
+                .artifactType(ArtifactType.FILE)
+                .storageType(ArtifactMetadataHelper.determineStorageFormat(filePath))
+                .filePath(filePath)
+                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
+                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
+                .storageLocation(storageStrategy.getStorageType().name())
+                .build();
+    }
+
+    @Override
+    public ArtifactDto toDto(ProductionArtifactDetailEntity detail) {
+        String downloadUrl = artifactAccessService.generateDownloadUrl(detail.getFilePath());
+
+        return new FileArtifactDto(
+                ArtifactType.FILE,
+                detail.getFilePath(),
+                downloadUrl,
+                detail.getFileName(),
+                detail.getContentType(),
+                detail.getStorageLocation()
+        );
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/FileArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/FileArtifactHandler.java
@@ -1,20 +1,15 @@
 package org.example.sharedprompts.module.domain.production.service.artifact;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
 import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
-import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
-import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
 import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
 import org.example.sharedprompts.module.dto.response.production.FileArtifactDto;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class FileArtifactHandler implements ArtifactHandler {
 
     private final ArtifactAccessService artifactAccessService;
@@ -24,19 +19,6 @@ public class FileArtifactHandler implements ArtifactHandler {
         return ArtifactType.FILE;
     }
 
-    @Override
-    public ProductionArtifactDetailEntity createDetail(
-            JobEntity job, String filePath, StorageStrategy storageStrategy) {
-
-        return ProductionArtifactDetailEntity.builder()
-                .artifactType(ArtifactType.FILE)
-                .storageType(ArtifactMetadataHelper.determineStorageFormat(filePath))
-                .filePath(filePath)
-                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
-                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
-                .storageLocation(storageStrategy.getStorageType().name())
-                .build();
-    }
 
     @Override
     public ArtifactDto toDto(ProductionArtifactDetailEntity detail) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ImageArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ImageArtifactHandler.java
@@ -1,20 +1,15 @@
 package org.example.sharedprompts.module.domain.production.service.artifact;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
 import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
-import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
-import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
 import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
 import org.example.sharedprompts.module.dto.response.production.ImageArtifactDto;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class ImageArtifactHandler implements ArtifactHandler {
 
     private final ArtifactAccessService artifactAccessService;
@@ -24,19 +19,6 @@ public class ImageArtifactHandler implements ArtifactHandler {
         return ArtifactType.IMAGE;
     }
 
-    @Override
-    public ProductionArtifactDetailEntity createDetail(
-            JobEntity job, String filePath, StorageStrategy storageStrategy) {
-
-        return ProductionArtifactDetailEntity.builder()
-                .artifactType(ArtifactType.IMAGE)
-                .storageType(ArtifactMetadataHelper.determineStorageFormat(filePath))
-                .filePath(filePath)
-                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
-                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
-                .storageLocation(storageStrategy.getStorageType().name())
-                .build();
-    }
 
     @Override
     public ArtifactDto toDto(ProductionArtifactDetailEntity detail) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ImageArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/ImageArtifactHandler.java
@@ -1,0 +1,54 @@
+package org.example.sharedprompts.module.domain.production.service.artifact;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
+import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
+import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
+import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
+import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
+import org.example.sharedprompts.module.dto.response.production.ImageArtifactDto;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageArtifactHandler implements ArtifactHandler {
+
+    private final ArtifactAccessService artifactAccessService;
+
+    @Override
+    public ArtifactType getSupportedType() {
+        return ArtifactType.IMAGE;
+    }
+
+    @Override
+    public ProductionArtifactDetailEntity createDetail(
+            JobEntity job, String filePath, StorageStrategy storageStrategy) {
+
+        return ProductionArtifactDetailEntity.builder()
+                .artifactType(ArtifactType.IMAGE)
+                .storageType(ArtifactMetadataHelper.determineStorageFormat(filePath))
+                .filePath(filePath)
+                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
+                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
+                .storageLocation(storageStrategy.getStorageType().name())
+                .build();
+    }
+
+    @Override
+    public ArtifactDto toDto(ProductionArtifactDetailEntity detail) {
+        String previewUrl = artifactAccessService.generatePreviewUrl(detail.getFilePath());
+
+        return new ImageArtifactDto(
+                ArtifactType.IMAGE,
+                detail.getFilePath(),
+                previewUrl,
+                detail.getFileName(),
+                detail.getContentType(),
+                detail.getStorageLocation()
+        );
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/TextArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/TextArtifactHandler.java
@@ -1,0 +1,46 @@
+package org.example.sharedprompts.module.domain.production.service.artifact;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
+import org.example.sharedprompts.module.domain.production.entity.production.StorageFormat;
+import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
+import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
+import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
+import org.example.sharedprompts.module.dto.response.production.TextArtifactDto;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TextArtifactHandler implements ArtifactHandler {
+
+    @Override
+    public ArtifactType getSupportedType() {
+        return ArtifactType.TEXT;
+    }
+
+    @Override
+    public ProductionArtifactDetailEntity createDetail(
+            JobEntity job, String filePath, StorageStrategy storageStrategy) {
+
+        return ProductionArtifactDetailEntity.builder()
+                .artifactType(ArtifactType.TEXT)
+                .storageType(ArtifactMetadataHelper.determineStorageFormat(filePath))
+                .filePath(filePath)
+                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
+                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
+                .storageLocation(storageStrategy.getStorageType().name())
+                .build();
+    }
+
+    @Override
+    public ArtifactDto toDto(ProductionArtifactDetailEntity detail) {
+        String content = detail.getStorageType() == StorageFormat.INLINE_TEXT
+                ? detail.getContent()
+                : null;
+        return new TextArtifactDto(ArtifactType.TEXT, content);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/TextArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/TextArtifactHandler.java
@@ -1,39 +1,18 @@
 package org.example.sharedprompts.module.domain.production.service.artifact;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.StorageFormat;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
-import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
-import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
 import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
 import org.example.sharedprompts.module.dto.response.production.TextArtifactDto;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
-@Slf4j
 public class TextArtifactHandler implements ArtifactHandler {
 
     @Override
     public ArtifactType getSupportedType() {
         return ArtifactType.TEXT;
-    }
-
-    @Override
-    public ProductionArtifactDetailEntity createDetail(
-            JobEntity job, String filePath, StorageStrategy storageStrategy) {
-
-        return ProductionArtifactDetailEntity.builder()
-                .artifactType(ArtifactType.TEXT)
-                .storageType(ArtifactMetadataHelper.determineStorageFormat(filePath))
-                .filePath(filePath)
-                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
-                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
-                .storageLocation(storageStrategy.getStorageType().name())
-                .build();
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/TextArtifactHandler.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/artifact/TextArtifactHandler.java
@@ -3,9 +3,13 @@ package org.example.sharedprompts.module.domain.production.service.artifact;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.StorageFormat;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
+import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
 import org.example.sharedprompts.module.dto.response.production.ArtifactDto;
 import org.example.sharedprompts.module.dto.response.production.TextArtifactDto;
 import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class TextArtifactHandler implements ArtifactHandler {
@@ -13,6 +17,24 @@ public class TextArtifactHandler implements ArtifactHandler {
     @Override
     public ArtifactType getSupportedType() {
         return ArtifactType.TEXT;
+    }
+
+    @Override
+    public ProductionArtifactDetailEntity createDetail(
+            String filePath,
+            StorageStrategy storageStrategy
+    ) {
+        String content = new String(storageStrategy.read(filePath), StandardCharsets.UTF_8);
+
+        return ProductionArtifactDetailEntity.builder()
+                .artifactType(getSupportedType())
+                .storageType(StorageFormat.INLINE_TEXT)
+                .content(content)
+                .filePath(filePath)
+                .fileName(ArtifactMetadataHelper.extractFileName(filePath))
+                .contentType(ArtifactMetadataHelper.determineContentType(filePath))
+                .storageLocation(storageStrategy.getStorageType().name())
+                .build();
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/PdfFormatConverter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/PdfFormatConverter.java
@@ -7,6 +7,8 @@ import org.example.sharedprompts.module.domain.production.service.format.pdf.Htm
 import org.example.sharedprompts.module.domain.production.service.format.pdf.PdfCssProvider;
 import org.springframework.stereotype.Component;
 
+import java.util.regex.Pattern;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -16,9 +18,16 @@ public class PdfFormatConverter implements FormatConverter {
     private final HtmlToPdfConverter htmlToPdfConverter;
     private final PdfCssProvider cssProvider;
 
+    private static final Pattern MARKDOWN_PATTERN = Pattern.compile(
+            "(?m)(^#{1,6}\\s|^[*\\-+]\\s|^\\d+\\.\\s|^```|\\[.+]\\(.+\\)|^>\\s|^\\|.+\\|)"
+    );
+
     @Override
     public byte[] convert(String content, String fileName) {
         try {
+            if (content == null) {
+                throw new FormatConversionException("Content must not be null for file: " + fileName);
+            }
             log.debug("Converting content to PDF - fileName: {}, contentLength: {}", fileName, content.length());
 
             String html = convertToHtml(content);
@@ -28,6 +37,9 @@ public class PdfFormatConverter implements FormatConverter {
             log.debug("PDF conversion completed - fileName: {}, pdfSize: {} bytes", fileName, pdfBytes.length);
             return pdfBytes;
 
+        } catch (FormatConversionException e) {
+            log.error("PDF conversion failed - fileName: {}", fileName, e);
+            throw e;
         } catch (Exception e) {
             log.error("PDF conversion failed - fileName: {}", fileName, e);
             throw new FormatConversionException("PDF conversion failed: " + e.getMessage(), e);
@@ -48,26 +60,7 @@ public class PdfFormatConverter implements FormatConverter {
         if (content == null || content.isBlank()) {
             return false;
         }
-
-        boolean hasMarkdownPattern = content.contains("#") 
-                || content.contains("*") 
-                || content.contains("`") 
-                || content.contains("[") 
-                || content.contains("|")
-                || content.contains("-") 
-                || content.contains(">");
-
-        if (!hasMarkdownPattern) {
-            return false;
-        }
-
-        try {
-            markdownToHtmlConverter.convert(content);
-            return true;
-        } catch (Exception e) {
-            log.debug("Markdown parsing failed, treating as plain text: {}", e.getMessage());
-            return false;
-        }
+        return MARKDOWN_PATTERN.matcher(content).find();
     }
 
     private String wrapPlainTextInHtml(String text) {
@@ -75,6 +68,9 @@ public class PdfFormatConverter implements FormatConverter {
                 .replace("&", "&amp;")
                 .replace("<", "&lt;")
                 .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("\r\n", "<br>")
+                .replace("\r", "<br>")
                 .replace("\n", "<br>");
         
         return "<p>" + escaped + "</p>";

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/PdfFormatConverter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/PdfFormatConverter.java
@@ -1,41 +1,83 @@
 package org.example.sharedprompts.module.domain.production.service.format;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.Font;
-import com.lowagie.text.PageSize;
-import com.lowagie.text.Paragraph;
-import com.lowagie.text.pdf.PdfWriter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.service.format.markdown.MarkdownToHtmlConverter;
+import org.example.sharedprompts.module.domain.production.service.format.pdf.HtmlToPdfConverter;
+import org.example.sharedprompts.module.domain.production.service.format.pdf.PdfCssProvider;
 import org.springframework.stereotype.Component;
 
-import java.io.ByteArrayOutputStream;
-
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class PdfFormatConverter implements FormatConverter {
 
+    private final MarkdownToHtmlConverter markdownToHtmlConverter;
+    private final HtmlToPdfConverter htmlToPdfConverter;
+    private final PdfCssProvider cssProvider;
+
     @Override
     public byte[] convert(String content, String fileName) {
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            Document document = new Document(PageSize.A4);
-            PdfWriter.getInstance(document, out);
+        try {
+            log.debug("Converting content to PDF - fileName: {}, contentLength: {}", fileName, content.length());
 
-            document.open();
+            String html = convertToHtml(content);
+            String css = cssProvider.getDefaultCss();
+            byte[] pdfBytes = htmlToPdfConverter.convert(html, css);
 
-            Font font = new Font(Font.HELVETICA, 11);
-            String[] paragraphs = content.split("\n\n");
-            for (String para : paragraphs) {
-                document.add(new Paragraph(para.trim(), font));
-                document.add(new Paragraph(" "));
-            }
-
-            document.close();
-            return out.toByteArray();
+            log.debug("PDF conversion completed - fileName: {}, pdfSize: {} bytes", fileName, pdfBytes.length);
+            return pdfBytes;
 
         } catch (Exception e) {
-            log.error("PDF conversion failed", e);
+            log.error("PDF conversion failed - fileName: {}", fileName, e);
             throw new FormatConversionException("PDF conversion failed: " + e.getMessage(), e);
         }
+    }
+
+    private String convertToHtml(String content) {
+        if (isMarkdown(content)) {
+            log.debug("Detected Markdown content, converting to HTML");
+            return markdownToHtmlConverter.convert(content);
+        } else {
+            log.debug("Plain text content detected, wrapping in HTML");
+            return wrapPlainTextInHtml(content);
+        }
+    }
+
+    private boolean isMarkdown(String content) {
+        if (content == null || content.isBlank()) {
+            return false;
+        }
+
+        boolean hasMarkdownPattern = content.contains("#") 
+                || content.contains("*") 
+                || content.contains("`") 
+                || content.contains("[") 
+                || content.contains("|")
+                || content.contains("-") 
+                || content.contains(">");
+
+        if (!hasMarkdownPattern) {
+            return false;
+        }
+
+        try {
+            markdownToHtmlConverter.convert(content);
+            return true;
+        } catch (Exception e) {
+            log.debug("Markdown parsing failed, treating as plain text: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private String wrapPlainTextInHtml(String text) {
+        String escaped = text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\n", "<br>");
+        
+        return "<p>" + escaped + "</p>";
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/markdown/FlexMarkMarkdownToHtmlConverter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/markdown/FlexMarkMarkdownToHtmlConverter.java
@@ -33,6 +33,9 @@ public class FlexMarkMarkdownToHtmlConverter implements MarkdownToHtmlConverter 
 
     @Override
     public String convert(String markdown) {
+        if (markdown == null || markdown.isBlank()) {
+            return "";
+        }
         try {
             Node document = parser.parse(markdown);
             return renderer.render(document);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/markdown/FlexMarkMarkdownToHtmlConverter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/markdown/FlexMarkMarkdownToHtmlConverter.java
@@ -1,0 +1,45 @@
+package org.example.sharedprompts.module.domain.production.service.format.markdown;
+
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.service.format.FormatConversionException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+public class FlexMarkMarkdownToHtmlConverter implements MarkdownToHtmlConverter {
+
+    private final Parser parser;
+    private final HtmlRenderer renderer;
+
+    public FlexMarkMarkdownToHtmlConverter() {
+        MutableDataSet options = new MutableDataSet();
+        options.set(Parser.EXTENSIONS, List.of(
+                TablesExtension.create(),
+                StrikethroughExtension.create(),
+                AutolinkExtension.create()
+        ));
+        this.parser = Parser.builder(options).build();
+        this.renderer = HtmlRenderer.builder(options).build();
+    }
+
+    @Override
+    public String convert(String markdown) {
+        try {
+            Node document = parser.parse(markdown);
+            return renderer.render(document);
+        } catch (Exception e) {
+            log.error("Markdown to HTML conversion failed", e);
+            throw new FormatConversionException("Markdown to HTML conversion failed: " + e.getMessage(), e);
+        }
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/markdown/MarkdownToHtmlConverter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/markdown/MarkdownToHtmlConverter.java
@@ -1,0 +1,7 @@
+package org.example.sharedprompts.module.domain.production.service.format.markdown;
+
+public interface MarkdownToHtmlConverter {
+
+    String convert(String markdown);
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/DefaultPdfCssProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/DefaultPdfCssProvider.java
@@ -41,10 +41,10 @@ public class DefaultPdfCssProvider implements PdfCssProvider {
                     color: #666;
                     font-style: italic;
                 }
-                table { width: 100%%; border-collapse: collapse; margin: 12pt 0; }
+                table { width: 100%; border-collapse: collapse; margin: 12pt 0; }
                 th, td { border: 1pt solid #ddd; padding: 8pt; text-align: left; }
                 th { background-color: #f0f0f0; font-weight: bold; }
-                img { max-width: 100%%; height: auto; }
+                img { max-width: 100%; height: auto; }
                 """;
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/DefaultPdfCssProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/DefaultPdfCssProvider.java
@@ -1,0 +1,51 @@
+package org.example.sharedprompts.module.domain.production.service.format.pdf;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultPdfCssProvider implements PdfCssProvider {
+
+    @Override
+    public String getDefaultCss() {
+        return """
+                @page {
+                    size: A4;
+                    margin: 2cm;
+                }
+                body {
+                    font-family: sans-serif;
+                    font-size: 11pt;
+                    line-height: 1.6;
+                    color: #333;
+                }
+                h1 { font-size: 22pt; border-bottom: 2pt solid #333; padding-bottom: 6pt; margin-top: 20pt; }
+                h2 { font-size: 17pt; margin-top: 16pt; }
+                h3 { font-size: 14pt; margin-top: 12pt; }
+                p { margin: 8pt 0; }
+                code {
+                    background-color: #f5f5f5;
+                    padding: 2pt 4pt;
+                    font-family: monospace;
+                    font-size: 10pt;
+                }
+                pre {
+                    background-color: #f5f5f5;
+                    padding: 10pt;
+                    border-left: 4pt solid #007acc;
+                    page-break-inside: avoid;
+                }
+                pre code { background-color: transparent; padding: 0; }
+                blockquote {
+                    border-left: 4pt solid #ddd;
+                    padding-left: 12pt;
+                    color: #666;
+                    font-style: italic;
+                }
+                table { width: 100%%; border-collapse: collapse; margin: 12pt 0; }
+                th, td { border: 1pt solid #ddd; padding: 8pt; text-align: left; }
+                th { background-color: #f0f0f0; font-weight: bold; }
+                img { max-width: 100%%; height: auto; }
+                """;
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/HtmlToPdfConverter.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/HtmlToPdfConverter.java
@@ -1,0 +1,7 @@
+package org.example.sharedprompts.module.domain.production.service.format.pdf;
+
+public interface HtmlToPdfConverter {
+
+    byte[] convert(String html, String css);
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/OpenHtmlToPdfConverterImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/OpenHtmlToPdfConverterImpl.java
@@ -1,0 +1,50 @@
+package org.example.sharedprompts.module.domain.production.service.format.pdf;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.service.format.FormatConversionException;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+
+@Component
+@Slf4j
+public class OpenHtmlToPdfConverterImpl implements HtmlToPdfConverter {
+
+    @Override
+    public byte[] convert(String html, String css) {
+        String fullHtml = wrapInHtmlDocument(html, css);
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PdfRendererBuilder builder = new PdfRendererBuilder();
+            builder.useFastMode();
+            builder.withHtmlContent(fullHtml, null);
+            builder.toStream(out);
+            builder.run();
+
+            return out.toByteArray();
+        } catch (Exception e) {
+            log.error("HTML to PDF conversion failed", e);
+            throw new FormatConversionException("HTML to PDF conversion failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String wrapInHtmlDocument(String bodyHtml, String css) {
+        String effectiveCss = (css != null && !css.isBlank()) ? css : "";
+        return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset="UTF-8"/>
+                    <style>
+                    %s
+                    </style>
+                </head>
+                <body>
+                %s
+                </body>
+                </html>
+                """.formatted(effectiveCss, bodyHtml);
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/PdfCssProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/format/pdf/PdfCssProvider.java
@@ -1,0 +1,7 @@
+package org.example.sharedprompts.module.domain.production.service.format.pdf;
+
+public interface PdfCssProvider {
+
+    String getDefaultCss();
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
@@ -32,14 +33,32 @@ public class ProductionArtifactService {
             String filePath,
             StorageStrategy storageStrategy
     ) {
-        ProductionCommandType commandType = ProductionCommandType.valueOf(job.getCommandType());
+        ProductionCommandType commandType;
+        try {
+            commandType = ProductionCommandType.valueOf(job.getCommandType());
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid command type: {}", job.getCommandType(), e);
+            throw new IllegalArgumentException("Invalid command type: " + job.getCommandType(), e);
+        }
+
         ArtifactType artifactType = ArtifactMetadataHelper.determineArtifactType(commandType);
-        ArtifactHandler handler = artifactHandlerRegistry.getHandler(artifactType);
+        
+        ArtifactHandler handler;
+        try {
+            handler = artifactHandlerRegistry.getHandler(artifactType);
+        } catch (IllegalArgumentException e) {
+            log.error("No ArtifactHandler found for type: {}", artifactType, e);
+            throw new IllegalArgumentException("No ArtifactHandler found for type: " + artifactType, e);
+        }
+
+        Instant startedAt = job.getStartedAt() != null 
+                ? job.getStartedAt() 
+                : job.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant();
 
         ProductionArtifactEntity artifact = ProductionArtifactEntity.builder()
                 .userId(job.getUserId())
                 .commandType(commandType)
-                .startedAt(job.getStartedAt() != null ? job.getStartedAt() : Instant.from(job.getCreatedAt()))
+                .startedAt(startedAt)
                 .completedAt(Instant.now())
                 .success(true)
                 .build();

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
@@ -51,9 +51,14 @@ public class ProductionArtifactService {
             throw new IllegalArgumentException("No ArtifactHandler found for type: " + artifactType, e);
         }
 
-        Instant startedAt = job.getStartedAt() != null 
-                ? job.getStartedAt() 
-                : job.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant();
+        Instant startedAt;
+        if (job.getStartedAt() != null) {
+            startedAt = job.getStartedAt();
+        } else if (job.getCreatedAt() != null) {
+            startedAt = job.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toInstant();
+        } else {
+            startedAt = Instant.now();
+        }
 
         ProductionArtifactEntity artifact = ProductionArtifactEntity.builder()
                 .userId(job.getUserId())
@@ -63,7 +68,7 @@ public class ProductionArtifactService {
                 .success(true)
                 .build();
 
-        ProductionArtifactDetailEntity detail = handler.createDetail(job, filePath, storageStrategy);
+        ProductionArtifactDetailEntity detail = handler.createDetail(filePath, storageStrategy);
         artifact.setDetail(detail);
 
         return productionArtifactRepository.save(artifact);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
@@ -6,7 +6,10 @@ import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactEntity;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
+import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
 import org.example.sharedprompts.module.domain.production.repository.production.ProductionArtifactRepository;
+import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandler;
+import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandlerRegistry;
 import org.example.sharedprompts.module.domain.production.service.storage.StorageStrategy;
 import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
 import org.springframework.stereotype.Service;
@@ -21,6 +24,7 @@ import java.time.Instant;
 public class ProductionArtifactService {
 
     private final ProductionArtifactRepository productionArtifactRepository;
+    private final ArtifactHandlerRegistry artifactHandlerRegistry;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public ProductionArtifactEntity createArtifact(
@@ -29,12 +33,8 @@ public class ProductionArtifactService {
             StorageStrategy storageStrategy
     ) {
         ProductionCommandType commandType = ProductionCommandType.valueOf(job.getCommandType());
-
-        var artifactType = ArtifactMetadataHelper.determineArtifactType(commandType);
-        var storageFormat = ArtifactMetadataHelper.determineStorageFormat(filePath);
-        String fileName = ArtifactMetadataHelper.extractFileName(filePath);
-        String contentType = ArtifactMetadataHelper.determineContentType(filePath);
-        String storageLocation = storageStrategy.getStorageType().name();
+        ArtifactType artifactType = ArtifactMetadataHelper.determineArtifactType(commandType);
+        ArtifactHandler handler = artifactHandlerRegistry.getHandler(artifactType);
 
         ProductionArtifactEntity artifact = ProductionArtifactEntity.builder()
                 .userId(job.getUserId())
@@ -44,15 +44,7 @@ public class ProductionArtifactService {
                 .success(true)
                 .build();
 
-        ProductionArtifactDetailEntity detail = ProductionArtifactDetailEntity.builder()
-                .artifactType(artifactType)
-                .storageType(storageFormat)
-                .filePath(filePath)
-                .fileName(fileName)
-                .contentType(contentType)
-                .storageLocation(storageLocation)
-                .build();
-
+        ProductionArtifactDetailEntity detail = handler.createDetail(job, filePath, storageStrategy);
         artifact.setDetail(detail);
 
         return productionArtifactRepository.save(artifact);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/LocalStorageStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/LocalStorageStrategy.java
@@ -24,7 +24,6 @@ public class LocalStorageStrategy implements StorageStrategy {
                 userId, jobId, fileName);
 
         try {
-            // 경로 생성: basePath/userId/jobId/fileName
             Path directory = Paths.get(basePath, String.valueOf(userId), jobId);
             Files.createDirectories(directory);
 
@@ -63,6 +62,38 @@ public class LocalStorageStrategy implements StorageStrategy {
                     userId, jobId, fileName, e);
             throw new LocalStorageException("Failed to store binary file: " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public byte[] read(String storagePath) {
+        log.info("Reading file locally - path: {}", storagePath);
+        try {
+            return Files.readAllBytes(Paths.get(storagePath));
+        } catch (IOException e) {
+            log.error("Failed to read file locally - path: {}", storagePath, e);
+            throw new LocalStorageException("Failed to read file: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean exists(String storagePath) {
+        return Files.exists(Paths.get(storagePath));
+    }
+
+    @Override
+    public void delete(String storagePath) {
+        log.info("Deleting file locally - path: {}", storagePath);
+        try {
+            Files.deleteIfExists(Paths.get(storagePath));
+        } catch (IOException e) {
+            log.error("Failed to delete file locally - path: {}", storagePath, e);
+            throw new LocalStorageException("Failed to delete file: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String generateAccessUrl(String storagePath, java.time.Duration ttl) {
+        return storagePath;
     }
 
     @Override

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/LocalStorageStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/LocalStorageStrategy.java
@@ -28,6 +28,7 @@ public class LocalStorageStrategy implements StorageStrategy {
             Files.createDirectories(directory);
 
             Path filePath = directory.resolve(fileName);
+            validateWithinBasePath(filePath);
             Files.writeString(filePath, content);
 
             log.info("File stored successfully - path: {}", filePath);
@@ -51,6 +52,7 @@ public class LocalStorageStrategy implements StorageStrategy {
             Files.createDirectories(directory);
 
             Path filePath = directory.resolve(fileName);
+            validateWithinBasePath(filePath);
             Files.write(filePath, data);
 
             log.info("Binary file stored successfully - path: {}, size: {} bytes", filePath, data.length);
@@ -61,6 +63,13 @@ public class LocalStorageStrategy implements StorageStrategy {
             log.error("Failed to store binary file locally - userId: {}, jobId: {}, fileName: {}",
                     userId, jobId, fileName, e);
             throw new LocalStorageException("Failed to store binary file: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateWithinBasePath(Path filePath) {
+        if (!filePath.normalize().toAbsolutePath().startsWith(
+                Paths.get(basePath).normalize().toAbsolutePath())) {
+            throw new LocalStorageException("Invalid fileName: path traversal detected");
         }
     }
 
@@ -108,7 +117,9 @@ public class LocalStorageStrategy implements StorageStrategy {
 
     @Override
     public String generateAccessUrl(String storagePath, java.time.Duration ttl) {
-        // 로컬 스토리지는 TTL 기반 URL을 지원하지 않으므로 경로를 그대로 반환
+        // 로컬 스토리지는 개발 환경 전용 - 운영 환경에서는 S3 등 외부 스토리지 사용 필요
+        log.warn("LocalStorage does not support secure access URLs. " +
+                "Internal path returned - do not use in production.");
         return storagePath;
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/LocalStorageStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/LocalStorageStrategy.java
@@ -64,11 +64,21 @@ public class LocalStorageStrategy implements StorageStrategy {
         }
     }
 
+    private Path validateAndResolvePath(String storagePath) {
+        Path resolved = Paths.get(storagePath).normalize().toAbsolutePath();
+        Path base = Paths.get(basePath).normalize().toAbsolutePath();
+        if (!resolved.startsWith(base)) {
+            throw new LocalStorageException(
+                    "Access denied: path is outside storage base directory");
+        }
+        return resolved;
+    }
+
     @Override
     public byte[] read(String storagePath) {
         log.info("Reading file locally - path: {}", storagePath);
         try {
-            return Files.readAllBytes(Paths.get(storagePath));
+            return Files.readAllBytes(validateAndResolvePath(storagePath));
         } catch (IOException e) {
             log.error("Failed to read file locally - path: {}", storagePath, e);
             throw new LocalStorageException("Failed to read file: " + e.getMessage(), e);
@@ -77,14 +87,19 @@ public class LocalStorageStrategy implements StorageStrategy {
 
     @Override
     public boolean exists(String storagePath) {
-        return Files.exists(Paths.get(storagePath));
+        try {
+            return Files.exists(validateAndResolvePath(storagePath));
+        } catch (LocalStorageException e) {
+            // If path is outside base directory, it doesn't exist in our storage
+            return false;
+        }
     }
 
     @Override
     public void delete(String storagePath) {
         log.info("Deleting file locally - path: {}", storagePath);
         try {
-            Files.deleteIfExists(Paths.get(storagePath));
+            Files.deleteIfExists(validateAndResolvePath(storagePath));
         } catch (IOException e) {
             log.error("Failed to delete file locally - path: {}", storagePath, e);
             throw new LocalStorageException("Failed to delete file: " + e.getMessage(), e);
@@ -93,6 +108,7 @@ public class LocalStorageStrategy implements StorageStrategy {
 
     @Override
     public String generateAccessUrl(String storagePath, java.time.Duration ttl) {
+        // 로컬 스토리지는 TTL 기반 URL을 지원하지 않으므로 경로를 그대로 반환
         return storagePath;
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/S3StorageStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/S3StorageStrategy.java
@@ -7,11 +7,15 @@ import org.example.sharedprompts.module.domain.production.service.storage.except
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 @Component
 @ConditionalOnProperty(name = "production.storage.type", havingValue = "S3")
@@ -19,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 public class S3StorageStrategy implements StorageStrategy {
 
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
 
     @Value("${production.storage.s3.bucket}")
     private String bucket;
@@ -26,8 +31,9 @@ public class S3StorageStrategy implements StorageStrategy {
     @Value("${production.storage.s3.prefix:production}")
     private String prefix;
 
-    public S3StorageStrategy(S3Client s3Client) {
+    public S3StorageStrategy(S3Client s3Client, S3Presigner s3Presigner) {
         this.s3Client = s3Client;
+        this.s3Presigner = s3Presigner;
     }
 
     @Override
@@ -62,6 +68,67 @@ public class S3StorageStrategy implements StorageStrategy {
         } catch (Exception e) {
             log.error("S3 upload failed - bucket: {}, key: {}", bucket, s3Key, e);
             throw new S3StorageException("S3 upload failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public byte[] read(String storagePath) {
+        log.info("Reading from S3 - bucket: {}, key: {}", bucket, storagePath);
+        try {
+            ResponseBytes<GetObjectResponse> responseBytes = s3Client.getObjectAsBytes(
+                    GetObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(storagePath)
+                            .build());
+            return responseBytes.asByteArray();
+        } catch (Exception e) {
+            log.error("S3 read failed - bucket: {}, key: {}", bucket, storagePath, e);
+            throw new S3StorageException("S3 read failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean exists(String storagePath) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(storagePath)
+                    .build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            log.error("S3 exists check failed - bucket: {}, key: {}", bucket, storagePath, e);
+            throw new S3StorageException("S3 exists check failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void delete(String storagePath) {
+        log.info("Deleting from S3 - bucket: {}, key: {}", bucket, storagePath);
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(storagePath)
+                    .build());
+        } catch (Exception e) {
+            log.error("S3 delete failed - bucket: {}, key: {}", bucket, storagePath, e);
+            throw new S3StorageException("S3 delete failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String generateAccessUrl(String storagePath, Duration ttl) {
+        log.debug("Generating presigned URL - bucket: {}, key: {}, ttl: {}", bucket, storagePath, ttl);
+        try {
+            GetObjectPresignRequest request = GetObjectPresignRequest.builder()
+                    .signatureDuration(ttl)
+                    .getObjectRequest(b -> b.bucket(bucket).key(storagePath))
+                    .build();
+            return s3Presigner.presignGetObject(request).url().toString();
+        } catch (Exception e) {
+            log.error("S3 presigned URL generation failed - key: {}", storagePath, e);
+            throw new S3StorageException("Presigned URL generation failed: " + e.getMessage(), e);
         }
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/S3StorageStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/S3StorageStrategy.java
@@ -73,7 +73,7 @@ public class S3StorageStrategy implements StorageStrategy {
 
     @Override
     public byte[] read(String storagePath) {
-        log.info("Reading from S3 - bucket: {}, key: {}", bucket, storagePath);
+        log.debug("Reading from S3 - bucket: {}, key: {}", bucket, storagePath);
         try {
             ResponseBytes<GetObjectResponse> responseBytes = s3Client.getObjectAsBytes(
                     GetObjectRequest.builder()
@@ -97,6 +97,12 @@ public class S3StorageStrategy implements StorageStrategy {
             return true;
         } catch (NoSuchKeyException e) {
             return false;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return false;
+            }
+            log.error("S3 exists check failed - bucket: {}, key: {}", bucket, storagePath, e);
+            throw new S3StorageException("S3 exists check failed: " + e.getMessage(), e);
         } catch (Exception e) {
             log.error("S3 exists check failed - bucket: {}, key: {}", bucket, storagePath, e);
             throw new S3StorageException("S3 exists check failed: " + e.getMessage(), e);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/StorageStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/storage/StorageStrategy.java
@@ -1,36 +1,34 @@
 package org.example.sharedprompts.module.domain.production.service.storage;
 
-/**
- * 파일 저장 전략 인터페이스
- * 
- * <p><strong>책임:</strong>
- * <ul>
- *   <li>저장 위치 전략 분리 (Local / S3 등)</li>
- *   <li>경로 생성 전략 (userId/jobId 기반)</li>
- *   <li>파일 저장 실패 시 retry 가능</li>
- *   <li>checksum 생성</li>
- * </ul>
- */
+import java.time.Duration;
+
 public interface StorageStrategy {
 
-    /**
-     * 텍스트 콘텐츠를 파일로 저장
-     */
     String store(String content, Long userId, String jobId, String fileName);
 
-    /**
-     * 바이너리 데이터를 파일로 저장 (Excel, PDF 등)
-     */
     String store(byte[] data, String contentType, Long userId, String jobId, String fileName);
 
-    /**
-     * 파일의 checksum 생성
-     */
     String generateChecksum(String content);
 
-    /**
-     * 저장 전략 타입
-     */
     StorageType getStorageType();
-}
 
+    default byte[] read(String storagePath) {
+        throw new UnsupportedOperationException(
+                "read() is not supported by " + getClass().getSimpleName());
+    }
+
+    default boolean exists(String storagePath) {
+        throw new UnsupportedOperationException(
+                "exists() is not supported by " + getClass().getSimpleName());
+    }
+
+    default void delete(String storagePath) {
+        throw new UnsupportedOperationException(
+                "delete() is not supported by " + getClass().getSimpleName());
+    }
+
+    default String generateAccessUrl(String storagePath, Duration ttl) {
+        throw new UnsupportedOperationException(
+                "generateAccessUrl() is not supported by " + getClass().getSimpleName());
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ArtifactDtoMapper.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ArtifactDtoMapper.java
@@ -22,6 +22,10 @@ public class ArtifactDtoMapper {
             throw new BaseException(ModuleErrorCode.VALIDATION_ERROR, "detail",
                     "ProductionArtifactDetailEntity must not be null");
         }
+        if (registry == null) {
+            throw new BaseException(ModuleErrorCode.VALIDATION_ERROR, "registry",
+                    "ArtifactHandlerRegistry must not be null");
+        }
         return registry.getHandler(detail.getArtifactType()).toDto(detail);
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ArtifactDtoMapper.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ArtifactDtoMapper.java
@@ -3,6 +3,7 @@ package org.example.sharedprompts.module.dto.response.production;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.StorageFormat;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandlerRegistry;
 import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
 import org.example.sharedprompts.module.exception.BaseException;
 import org.example.sharedprompts.module.exception.ModuleErrorCode;
@@ -14,14 +15,26 @@ public class ArtifactDtoMapper {
     private ArtifactDtoMapper() {
     }
 
-    public static ArtifactDto toDto(ProductionArtifactDetailEntity detail) {
-        return toDto(detail, null);
+    public static ArtifactDto toDto(
+            ProductionArtifactDetailEntity detail,
+            ArtifactHandlerRegistry registry) {
+        if (detail == null) {
+            throw new BaseException(ModuleErrorCode.VALIDATION_ERROR, "detail",
+                    "ProductionArtifactDetailEntity must not be null");
+        }
+        return registry.getHandler(detail.getArtifactType()).toDto(detail);
     }
 
+    @Deprecated
+    public static ArtifactDto toDto(ProductionArtifactDetailEntity detail) {
+        return toDto(detail, (ArtifactAccessService) null);
+    }
+
+    @Deprecated
     public static ArtifactDto toDto(
             ProductionArtifactDetailEntity detail,
             ArtifactAccessService artifactAccessService) {
-        
+
         if (detail == null) {
             throw new BaseException(ModuleErrorCode.VALIDATION_ERROR, "detail", "ProductionArtifactDetailEntity must not be null");
         }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ProductionResponseDtoMapper.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ProductionResponseDtoMapper.java
@@ -1,25 +1,54 @@
 package org.example.sharedprompts.module.dto.response.production;
 
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactEntity;
+import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandlerRegistry;
 import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
 
 public class ProductionResponseDtoMapper {
 
-    public static ProductionResponseDto toDto(ProductionArtifactEntity entity) {
-        return toDto(entity, null);
+    private ProductionResponseDtoMapper() {
     }
 
     public static ProductionResponseDto toDto(
             ProductionArtifactEntity entity,
-            ArtifactAccessService artifactAccessService) {
-        
+            ArtifactHandlerRegistry artifactHandlerRegistry) {
+
         ProductionStatus status = determineStatus(entity);
-        
+
+        ArtifactDto artifact = null;
+        if (status == ProductionStatus.SUCCESS && entity.getDetail() != null) {
+            artifact = ArtifactDtoMapper.toDto(entity.getDetail(), artifactHandlerRegistry);
+        }
+
+        return new ProductionResponseDto(
+                entity.getId(),
+                status,
+                status == ProductionStatus.FAILED && entity.getDetail() != null
+                        ? entity.getDetail().getErrorMessage()
+                        : null,
+                entity.getStartedAt(),
+                entity.getCompletedAt(),
+                artifact
+        );
+    }
+
+    @Deprecated
+    public static ProductionResponseDto toDto(ProductionArtifactEntity entity) {
+        return toDto(entity, (ArtifactAccessService) null);
+    }
+
+    @Deprecated
+    public static ProductionResponseDto toDto(
+            ProductionArtifactEntity entity,
+            ArtifactAccessService artifactAccessService) {
+
+        ProductionStatus status = determineStatus(entity);
+
         ArtifactDto artifact = null;
         if (status == ProductionStatus.SUCCESS && entity.getDetail() != null) {
             artifact = ArtifactDtoMapper.toDto(entity.getDetail(), artifactAccessService);
         }
-        
+
         return new ProductionResponseDto(
                 entity.getId(),
                 status,

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ProductionResponseDtoMapper.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/production/ProductionResponseDtoMapper.java
@@ -4,7 +4,7 @@ import org.example.sharedprompts.module.domain.production.entity.production.Prod
 import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandlerRegistry;
 import org.example.sharedprompts.module.domain.production.service.production.ArtifactAccessService;
 
-public class ProductionResponseDtoMapper {
+public final class ProductionResponseDtoMapper {
 
     private ProductionResponseDtoMapper() {
     }
@@ -20,16 +20,7 @@ public class ProductionResponseDtoMapper {
             artifact = ArtifactDtoMapper.toDto(entity.getDetail(), artifactHandlerRegistry);
         }
 
-        return new ProductionResponseDto(
-                entity.getId(),
-                status,
-                status == ProductionStatus.FAILED && entity.getDetail() != null
-                        ? entity.getDetail().getErrorMessage()
-                        : null,
-                entity.getStartedAt(),
-                entity.getCompletedAt(),
-                artifact
-        );
+        return buildResponseDto(entity, status, artifact);
     }
 
     @Deprecated
@@ -49,6 +40,13 @@ public class ProductionResponseDtoMapper {
             artifact = ArtifactDtoMapper.toDto(entity.getDetail(), artifactAccessService);
         }
 
+        return buildResponseDto(entity, status, artifact);
+    }
+
+    private static ProductionResponseDto buildResponseDto(
+            ProductionArtifactEntity entity,
+            ProductionStatus status,
+            ArtifactDto artifact) {
         return new ProductionResponseDto(
                 entity.getId(),
                 status,


### PR DESCRIPTION
## 주요 변경사항

### 1. P1 중기 개선 사항 완료

#### PDF 변환 개선
- `PdfFormatConverter`: Markdown → HTML → PDF 파이프라인 통합
  - Markdown 콘텐츠 자동 감지 및 변환
  - FlexMark를 사용한 Markdown 파싱 (제목, 리스트, 코드 블록, 테이블 등 지원)
  - OpenHTMLToPDF를 사용한 HTML → PDF 변환
  - CSS 스타일링 지원
  - 일반 텍스트도 HTML로 감싸서 PDF 변환 지원

#### StorageStrategy 인터페이스 확장
- `read()`, `exists()`, `delete()`, `generateAccessUrl()` 메서드 구현
- `S3StorageStrategy`, `LocalStorageStrategy` 모두 지원

#### ArtifactHandler 전략 패턴
- `ArtifactHandlerRegistry`로 타입별 Handler 관리
- `TextArtifactHandler`, `FileArtifactHandler`, `ImageArtifactHandler` 구현

### 2. 코드 구조 정리

#### 폴더 구조 개선
- PDF 관련 코드를 `format/pdf/` 서브폴더로 분리
  - `HtmlToPdfConverter.java`
  - `OpenHtmlToPdfConverterImpl.java`
  - `PdfCssProvider.java`
  - `DefaultPdfCssProvider.java`

- Markdown 관련 코드를 `format/markdown/` 서브폴더로 분리
  - `MarkdownToHtmlConverter.java`
  - `FlexMarkMarkdownToHtmlConverter.java`

#### 주석 최소화
- 불필요한 JavaDoc 주석 제거
- 코드 자체로 의도가 명확하도록 정리
- `StorageStrategy`, `ArtifactHandler` 인터페이스 주석 제거

### 3. 의존성 업데이트
- OpenHTMLToPDF 버전 업그레이드: `1.1.24` → `1.1.37`
- 패키지 경로 변경: `com.openhtmltopdf` → `io.github.openhtmltopdf`

## 변경된 파일

### 신규 생성
- `format/pdf/HtmlToPdfConverter.java`
- `format/pdf/OpenHtmlToPdfConverterImpl.java`
- `format/pdf/PdfCssProvider.java`
- `format/pdf/DefaultPdfCssProvider.java`
- `format/markdown/MarkdownToHtmlConverter.java`
- `format/markdown/FlexMarkMarkdownToHtmlConverter.java`

### 수정
- `PdfFormatConverter.java` (Markdown → HTML → PDF 파이프라인 통합)
- `StorageStrategy.java` (주석 제거)
- `ArtifactHandler.java` (주석 제거)
- `LocalStorageStrategy.java` (주석 제거)
- `build.gradle` (OpenHTMLToPDF 의존성 업데이트)

### 삭제
- `format/HtmlToPdfConverter.java` (pdf 서브폴더로 이동)
- `format/OpenHtmlToPdfConverterImpl.java` (pdf 서브폴더로 이동)
- `format/PdfCssProvider.java` (pdf 서브폴더로 이동)
- `format/DefaultPdfCssProvider.java` (pdf 서브폴더로 이동)
- `format/MarkdownToHtmlConverter.java` (markdown 서브폴더로 이동)
- `format/FlexMarkMarkdownToHtmlConverter.java` (markdown 서브폴더로 이동)

## 효과
- 코드 구조 명확화: PDF/Markdown 관련 코드가 논리적으로 그룹화됨
- 확장성 향상: 새로운 변환 타입 추가 시 서브폴더 구조로 관리 용이
- 코드 가독성 개선: 불필요한 주석 제거로 핵심 로직에 집중
- PDF 변환 품질 향상: Markdown 구조 완벽 지원 및 CSS 스타일링 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Markdown → HTML → PDF 통합 변환 파이프라인 추가(기본 스타일 포함)
  * 텍스트/이미지/파일별 아티팩트 핸들러로 출력 형식·미리보기·다운로드 URL 개선
  * 로컬·S3 저장소에서 읽기·존재확인·삭제·접근 URL 생성 기능 확장
  * 프로덕션 생성 API에 텍스트/이미지/이메일/문서 등 전용 엔드포인트 추가

* **버그 수정 및 안정성**
  * 로컬 저장 시 경로 검증 추가로 경로 탈출 방지 강화
  * 생산 결과의 시간/타임존·예외 처리 보강 및 안전한 에러 흐름 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->