### PR TITLE
feat(production): add literary generation (POEM, SHORT_STORY, NOVEL, …

### DIFF
--- a/sharedPrompts/docs/literary-generation-architecture.md
+++ b/sharedPrompts/docs/literary-generation-architecture.md
@@ -8,7 +8,7 @@
 
 ## 2. 패키지 구조
 
-```
+```text
 module/domain/production/
 ├── model/
 │   ├── contract/command/
@@ -51,7 +51,7 @@ module/domain/production/
 
 ## 3. 처리 흐름
 
-```
+```text
 [Request] LiteraryProductionRequestDto(literaryType, fileName, format, userInput)
     → ProductionApplicationService.produce()
     → LiteraryCommandFactory.createCommand() → LiteraryCommand
@@ -104,7 +104,7 @@ sequenceDiagram
     Strategy-->>Processor: rawContent
     loop 검증 실패 시 최대 2회 재시도
         Processor->>Validator: validate(rawContent)
-        Validator-->>Processor: ValidationResult
+        Validator-->>Processor: LiteraryValidationResult
     end
     Processor->>Pipeline: run(rawContent, job)
     Pipeline->>Pipeline: Markdown 정제 → original.txt
@@ -124,7 +124,7 @@ sequenceDiagram
 ```java
 public interface LiteraryGenerationStrategy {
     LiteraryType getLiteraryType();
-    String generate(JobEntity job, LiteraryCommand command, String composedPrompt, AIService aiService);
+    String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor);
 }
 ```
 
@@ -133,7 +133,7 @@ public interface LiteraryGenerationStrategy {
 ```java
 public interface LiteraryOutputValidator {
     LiteraryType getLiteraryType();
-    ValidationResult validate(String rawContent);
+    LiteraryValidationResult validate(String rawContent);
 }
 ```
 

--- a/sharedPrompts/docs/literary-generation-architecture.md
+++ b/sharedPrompts/docs/literary-generation-architecture.md
@@ -1,0 +1,169 @@
+# 완성 작품 생성(Literary Generation) 아키텍처
+
+## 1. 개요
+
+- **목표**: POEM | SHORT_STORY | NOVEL | SCRIPT 형식에 맞는 완성 작품 생성
+- **전제**: 프롬프트 템플릿(DB), 사용자 입력(user_input), LiteraryType
+- **결과물**: S3에 파일 저장, HTML 미리보기 + PDF 다운로드 지원
+
+## 2. 패키지 구조
+
+```
+module/domain/production/
+├── model/
+│   ├── contract/command/
+│   │   ├── ProductionCommandType.java  (+ LITERARY)
+│   │   └── ProductionCommand.java
+│   ├── executor/
+│   │   └── literary/
+│   │       └── LiteraryCommand.java
+│   └── literary/
+│       └── LiteraryType.java           (POEM, SHORT_STORY, NOVEL, SCRIPT)
+├── service/
+│   ├── prompt/
+│   │   ├── PromptTemplateService.java (LITERARY 분기)
+│   │   ├── PromptMerger.java          (LITERARY → LiteraryPromptComposer)
+│   │   └── literary/
+│   │       ├── LiteraryPromptComposer.java      (Prompt Composition Layer)
+│   │       └── LiteraryFormatRules.java         (형식 강제 규칙)
+│   ├── literary/
+│   │   ├── LiteraryGenerationStrategy.java      (Strategy 인터페이스)
+│   │   ├── impl/
+│   │   │   ├── PoemGenerationStrategy.java
+│   │   │   ├── ShortStoryGenerationStrategy.java
+│   │   │   ├── NovelGenerationStrategy.java      (장 단위, 토큰 제한, 병합)
+│   │   │   └── ScriptGenerationStrategy.java
+│   │   ├── validation/
+│   │   │   ├── LiteraryOutputValidator.java
+│   │   │   └── impl/ (LiteraryType별 검증)
+│   │   ├── pipeline/
+│   │   │   └── LiteraryOutputPipeline.java      (MD 정제 → HTML → PDF → S3)
+│   │   └── novel/
+│   │       ├── ChapterPlan.java
+│   │       ├── TokenEstimator.java
+│   │       └── ChapterMergeHelper.java
+│   └── ...
+├── application/
+│   ├── factory/impl/
+│   │   └── LiteraryCommandFactory.java
+│   └── ...
+```
+
+## 3. 처리 흐름
+
+```
+[Request] LiteraryProductionRequestDto(literaryType, fileName, format, userInput)
+    → ProductionApplicationService.produce()
+    → LiteraryCommandFactory.createCommand() → LiteraryCommand
+    → ValidatorRegistry.validate(LiteraryCommand)
+    → JobQueueService.enqueueJob(promptId, userId, LiteraryCommand, userInput)
+
+[Async Job] JobProcessorDelegate.processJob(jobId)
+    → CommandDeserializer → LiteraryCommand
+    → PromptTemplateService.mergePrompt() → LiteraryPromptComposer.compose()
+    → LiteraryGenerationStrategyRegistry.getStrategy(literaryType).generate()
+        [NOVEL만] ChapterPlan → per-chapter generate (token 제한) → merge
+    → LiteraryOutputValidator.validate() → 실패 시 재요청(Retry, 최대 2회)
+    → LiteraryOutputPipeline.run(markdown)
+        → Markdown 정제 → original.txt
+        → Markdown → HTML → preview.html
+        → HTML → PDF (OpenHTMLToPDF) → final.pdf
+        → S3 업로드 (production/{userId}/{jobId}/original.txt | preview.html | final.pdf)
+    → JobStateService.markStoredLiterary(jobId, originalKey, previewKey, pdfKey)
+    → PresignedUrlService (기존)로 다운로드/미리보기 URL 제공
+```
+
+### 처리 흐름 다이어그램 (Mermaid)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Controller
+    participant AppService
+    participant Queue
+    participant Processor
+    participant PromptComposer
+    participant Strategy
+    participant Validator
+    participant Pipeline
+    participant S3
+    participant JobState
+
+    Client->>Controller: POST /prompts/{id}/production/literary
+    Controller->>AppService: produce(promptId, userId, LiteraryProductionRequestDto)
+    AppService->>AppService: LiteraryCommandFactory.createCommand()
+    AppService->>Queue: enqueueJob(LiteraryCommand, userInput)
+    Queue-->>Client: JobResponseDto (jobId)
+
+    Note over Queue,Processor: 비동기 처리
+    Processor->>Processor: CommandDeserializer → LiteraryCommand
+    Processor->>PromptComposer: compose(template, userInput, literaryType)
+    PromptComposer-->>Processor: composedPrompt
+    Processor->>Strategy: generate(job, command, prompt, aiExecutor)
+    Strategy->>Strategy: LiteraryAIExecutor.execute() [또는 NOVEL 시 장별 호출]
+    Strategy-->>Processor: rawContent
+    loop 검증 실패 시 최대 2회 재시도
+        Processor->>Validator: validate(rawContent)
+        Validator-->>Processor: ValidationResult
+    end
+    Processor->>Pipeline: run(rawContent, job)
+    Pipeline->>Pipeline: Markdown 정제 → original.txt
+    Pipeline->>Pipeline: MD→HTML → preview.html
+    Pipeline->>Pipeline: HTML→PDF → final.pdf
+    Pipeline->>S3: upload(original.txt, preview.html, final.pdf)
+    S3-->>Pipeline: s3Keys
+    Pipeline-->>Processor: LiteraryPipelineResult
+    Processor->>JobState: markStoredLiterary(jobId, key1, key2, key3)
+    JobState->>JobState: createArtifactForLiterary (3 details), complete(job)
+```
+
+## 4. 핵심 인터페이스
+
+### LiteraryGenerationStrategy
+
+```java
+public interface LiteraryGenerationStrategy {
+    LiteraryType getLiteraryType();
+    String generate(JobEntity job, LiteraryCommand command, String composedPrompt, AIService aiService);
+}
+```
+
+### LiteraryOutputValidator
+
+```java
+public interface LiteraryOutputValidator {
+    LiteraryType getLiteraryType();
+    ValidationResult validate(String rawContent);
+}
+```
+
+### LiteraryPromptComposer
+
+- `compose(promptContent, userInput, literaryType)`: 시스템/템플릿 + 사용자 입력 + LiteraryType별 형식 규칙 결합
+- 형식 강제 규칙 포함, "결과물 외 설명 금지" 명시
+
+## 5. 파일 구조 (S3)
+
+- `production/{tenantId?}/{userId}/{jobId}/original.txt`  — 원본(정제된 Markdown 또는 텍스트)
+- `production/{tenantId?}/{userId}/{jobId}/preview.html` — HTML 미리보기
+- `production/{tenantId?}/{userId}/{jobId}/final.pdf`    — PDF 다운로드
+
+## 6. 형식별 주의사항 (프롬프트/검증)
+
+| 타입 | 규칙 |
+|------|------|
+| POEM | 행 단위 구성, 불필요한 산문 제거 |
+| SHORT_STORY | 도입-전개-클라이맥스-결말, 완결된 단편 |
+| NOVEL | 장(Chapter) 단위, 토큰 초과 시 분할 생성 후 병합 |
+| SCRIPT | 소설 서술체 금지, 등장인물 이름 + 대사, Scene 구분 필수 |
+
+## 7. 예외 처리
+
+- **Validation Layer**: AI 응답이 형식을 따르지 않으면 `LiteraryOutputValidator`가 실패 반환
+- **Retry**: 형식 검증 실패 시 재요청 (기존 AIRetryExecutor 확장 또는 Literary 전용 retry 루프)
+- Retry Policy: 최대 N회, 백오프 적용
+
+## 8. 확장성
+
+- 새 LiteraryType 추가 시: enum 추가, Strategy 구현체, Validator 구현체, FormatRules 텍스트 추가
+- 전략/검증은 Registry로 조회하여 O(1) 확장

--- a/sharedPrompts/docs/s3-presigned-url-time-sync-and-recovery.md
+++ b/sharedPrompts/docs/s3-presigned-url-time-sync-and-recovery.md
@@ -148,7 +148,7 @@ docker run --rm <image> date -u
 - **엔드포인트**: `GET /artifact/{id}/access?type=download` 또는 `GET /artifact/{id}/access?type=preview`
 - **동작**:
   1. 서버가 인증/소유권 검증 후 Presigned URL 생성 (요청 시점의 “현재 시각” 사용).
-  2. `302 Found` + `Location: <presigned-url>` 반환.
+  2. `302 Found` + `Location: <presigned-url>` 반환. 응답에 `Cache-Control: no-store, no-cache` 헤더를 포함하여 클라이언트가 302의 Location을 캐싱하지 않도록 합니다(캐시 시 만료된 Presigned URL로 이동해 403이 발생할 수 있음).
   3. 클라이언트(브라우저/앱)는 해당 URL로 리다이렉트되어 S3에서 직접 다운로드/미리보기.
 
 **장점**
@@ -190,6 +190,7 @@ public ResponseEntity<Void> accessArtifact(
     String presignedUrl = storageCommandService.generateDownloadPresignedUrl(artifactId, principal.getUserId());
     return ResponseEntity.status(HttpStatus.FOUND)
             .location(URI.create(presignedUrl))
+            .header("Cache-Control", "no-store, no-cache")
             .build();
 }
 ```

--- a/sharedPrompts/docs/s3-presigned-url-time-sync-and-recovery.md
+++ b/sharedPrompts/docs/s3-presigned-url-time-sync-and-recovery.md
@@ -1,0 +1,206 @@
+# S3 Presigned URL: 시간 동기화 점검 가이드 및 재발 방지
+
+## 1. 문제 원인 분석
+
+### 1.1 `AccessDenied` / `Request has expired` 발생 원리 (AWS 공식)
+
+- **SigV4 Presigned URL**은 다음 두 시간 요소로 유효성이 결정됩니다.
+  - **X-Amz-Date**: 서명 시점의 요청 시간 (UTC, 형식: `yyyyMMddTHHmmssZ`)
+  - **X-Amz-Expires**: 위 시점부터의 유효 기간(초)
+
+- S3는 **요청을 수신한 시점의 자신의 서버 시간**과 다음을 비교합니다.
+  - `X-Amz-Date ≤ 현재(S3) 시간`
+  - `X-Amz-Date + X-Amz-Expires ≥ 현재(S3) 시간`
+
+- **“생성 직후에도 Request has expired”**가 나오는 전형적인 원인:
+  - **Presigned URL을 생성한 서버의 시계가 S3(UTC)보다 느리다(뒤처져 있다).**
+  - 서버가 사용한 “현재 시각”(X-Amz-Date)이 이미 S3 기준으로는 “과거”이고, 그 과거 시각 + Expires도 S3 “현재”보다 이전이면, S3는 요청을 “이미 만료된 요청”으로 판단해 `Request has expired`를 반환합니다.
+
+즉, **추측이 아니라 AWS 동작**: 서명 시 사용한 시간이 **UTC 기준으로 S3와 일치하지 않거나 서버 시계가 느리면** 생성 직후에도 만료로 처리될 수 있습니다.
+
+### 1.2 커스텀 서명 vs SDK 사용 여부
+
+- 이 프로젝트는 **AWS SDK v3 `S3Presigner`**만 사용합니다. 커스텀 SigV4 구현은 없습니다.
+- `S3Presigner`는 **JVM이 인식하는 현재 시각**(시스템 시계)을 사용해 X-Amz-Date와 서명을 생성합니다.
+- 따라서 **시스템 시계가 잘못되거나 타임존/드리프트 문제**가 있으면 동일 증상이 발생합니다.
+
+---
+
+## 2. 시간 검증 체크리스트
+
+Presigned URL 생성 시 아래 로그가 출력되도록 되어 있습니다. 403 발생 시 다음을 비교·기록하세요.
+
+| 항목 | 설명 | 확인 방법 |
+|------|------|-----------|
+| **Instant.now()** | JVM이 사용한 현재 시각(UTC) | 로그 `[Presign time diagnostic]` |
+| **ZonedDateTime.now(UTC)** | UTC 기준 현재 시각 | 동일 로그 |
+| **systemDefaultZone** | JVM 기본 타임존 | 동일 로그 (드리프트 원인 분석용) |
+| **X-Amz-Date (in URL)** | Presigned URL에 들어간 서명 시각 | 동일 로그 또는 URL 쿼리 파라미터 |
+| **S3 ServerTime** | S3가 403 응답 본문에 넣는 서버 시간 | 403 XML 응답의 `<ServerTime>` |
+
+**분석 방법**
+
+- 로그의 `X-Amz-Date`와 403 응답의 `<ServerTime>`을 UTC로 비교합니다.
+- `X-Amz-Date`가 `ServerTime`보다 **몇 초/분 이상 과거**이면, Presigned URL을 생성한 서버의 시계가 S3보다 느린 것입니다. → **해당 서버의 시계 동기화(NTP 등) 필요.**
+
+---
+
+## 3. 시간 동기화 점검 가이드
+
+### 3.1 Linux (호스트)
+
+**현재 시간(UTC) 확인**
+
+```bash
+date -u
+```
+
+**타임존 및 NTP 동기화 상태 확인**
+
+```bash
+timedatectl
+```
+
+- `System clock synchronized: yes` 인지 확인.
+- `NTP service: active` 또는 `Time zone: UTC` 등으로 의도한 설정인지 확인.
+
+**NTP/chrony 권장 설정 (예: chrony)**
+
+```bash
+# chrony 설치 (예: RHEL/CentOS/Amazon Linux)
+sudo yum install -y chrony
+# 또는 Debian/Ubuntu
+sudo apt-get install -y chrony
+
+# 설정 예시: /etc/chrony.conf
+# pool ntp.aws.amazon.com iburst   # AWS NTP (리전별 엔드포인트 있음)
+# 또는
+# pool 2.pool.ntp.org iburst
+# driftfile /var/lib/chrony/drift
+# makestep 0.1 3
+
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
+sudo chronyc tracking
+sudo chronyc sources
+```
+
+- AWS 환경에서는 `ntp.aws.amazon.com` 등 AWS NTP 사용을 권장합니다.
+
+### 3.2 Docker 컨테이너 내부 시간 확인
+
+컨테이너는 호스트 커널의 시계를 공유하지만, 컨테이너만 재시작된 경우 등에 시간이 어긋날 수 있습니다.
+
+**컨테이너 안에서 확인**
+
+```bash
+# 컨테이너 셸 접속 후
+date -u
+```
+
+**호스트와 비교**
+
+```bash
+# 호스트
+date -u
+
+# 컨테이너 (이미지에 따라 다름)
+docker run --rm <image> date -u
+```
+
+- 호스트와 1분 이상 차이나면 NTP 동기화를 호스트와 컨테이너 모두에서 점검하세요.
+- Docker Compose/Kubernetes에서는 호스트의 NTP 동기화가 우선입니다.
+
+### 3.3 요약
+
+- **Presigned URL을 생성하는 서버/컨테이너**의 시계가 **UTC 기준으로 정확**해야 합니다.
+- `date -u`와 `timedatectl`로 주기적으로 확인하고, NTP(chrony 등)로 동기화를 유지하세요.
+
+---
+
+## 4. 안정성 개선 (적용/권장 사항)
+
+### 4.1 Presigned URL 만료 시간
+
+- **기본 TTL을 15분(900초)으로 확장**해 두었습니다. (보안 요구사항에 따라 최대 60분까지 조정 가능.)
+- 설정:
+  - `production.storage.s3.presigned-url.ttl-seconds` (기본값: 900)
+  - `artifact.url.default-ttl` (기본값: 900)
+- 클록이 소폭 느린 환경에서도 짧은 TTL로 인한 “생성 직후 만료” 가능성을 줄이기 위함입니다.
+
+### 4.2 프론트엔드: 403 시 URL 재발급
+
+- Presigned URL로 GET 요청 시 **403(Forbidden)** 이 오면:
+  - 응답 본문에 `Request has expired` 또는 `AccessDenied`가 포함된 경우, **같은 아티팩트에 대해 Presigned URL 재발급 API를 한 번 호출**한 뒤, 새 URL로 다시 요청하는 로직을 권장합니다.
+- 예시 흐름:
+  1. 아티팩트 접근용 Presigned URL 발급 API 호출 → URL 수신
+  2. 해당 URL로 GET (이미지/다운로드)
+  3. **403 수신 시** → (선택) 본문에 “expired”/“AccessDenied” 포함 여부 확인 → 재발급 API 호출 → 새 URL로 1회 재시도
+- 재시도는 1회로 제한하는 것을 권장합니다 (무한 루프 방지).
+
+### 4.3 구조 개선 제안: Presigned URL 직접 반환 대신 302 리다이렉트
+
+- **현재**: 클라이언트가 “Presigned URL 발급 API”를 호출해 URL을 받고, 해당 URL로 직접 S3에 요청합니다.
+- **개선 제안**: “아티팩트 접근”을 하나의 진입점으로 묶고, 서버가 Presigned URL을 생성한 뒤 **302 Redirect**로 그 URL로 보내는 방식입니다.
+
+**예시**
+
+- **엔드포인트**: `GET /artifact/{id}/access?type=download` 또는 `GET /artifact/{id}/access?type=preview`
+- **동작**:
+  1. 서버가 인증/소유권 검증 후 Presigned URL 생성 (요청 시점의 “현재 시각” 사용).
+  2. `302 Found` + `Location: <presigned-url>` 반환.
+  3. 클라이언트(브라우저/앱)는 해당 URL로 리다이렉트되어 S3에서 직접 다운로드/미리보기.
+
+**장점**
+
+- Presigned URL을 클라이언트에 노출하지 않고, “접근 시점”에 맞춰 매번 새로 생성할 수 있음.
+- 생성 직후 바로 리다이렉트되므로, 서버 시계가 정상이라면 “생성 직후 만료” 가능성이 거의 없음.
+- 403이 나오면 “아티팩트 접근 URL”을 다시 호출하면 서버가 새 Presigned URL을 만들어 302로 주므로, 재발급 로직을 서버 진입점 한 곳으로 모을 수 있음.
+
+**구현 시 유의**
+
+- 다운로드 시 `Content-Disposition` 등은 Presigned URL 생성 시 `GetObjectRequest`에 이미 포함되므로, 302 응답 본문은 비워 두거나 짧은 HTML 메시지만 넣으면 됩니다.
+
+---
+
+## 5. 수정 코드 요약 (Java)
+
+### 5.1 시간 진단 로그 (이미 반영됨)
+
+- `S3PresignedUrlService`에서 Presigned URL 생성 직후:
+  - `Instant.now()`, `ZonedDateTime.now(ZoneOffset.UTC)`, `ZoneId.systemDefault()` 로그 출력
+  - 생성된 URL에서 `X-Amz-Date` 쿼리 파라미터 추출 후 로그 출력
+- 로그 메시지: `[Presign time diagnostic] operation=... | Instant.now()=... | ZonedDateTime.now(UTC)=... | systemDefaultZone=... | X-Amz-Date(in URL)=...`
+
+### 5.2 Presigned URL TTL
+
+- `ProductionS3Properties.PresignedUrl.ttlSeconds` 기본값: **900** (15분)
+- `application.yml`: `production.storage.s3.presigned-url.ttl-seconds` 기본값 **900**
+- `artifact.url.default-ttl` 기본값 **900**
+
+### 5.3 302 리다이렉트 예시 (제안)
+
+```java
+// 예시: 다운로드 접근 시 Presigned URL로 302 리다이렉트
+@GetMapping("/artifact/{artifactId}/access")
+public ResponseEntity<Void> accessArtifact(
+        @PathVariable Long artifactId,
+        @RequestParam(defaultValue = "download") String type,
+        @AuthenticationPrincipal UserPrincipal principal) {
+    String presignedUrl = storageCommandService.generateDownloadPresignedUrl(artifactId, principal.getUserId());
+    return ResponseEntity.status(HttpStatus.FOUND)
+            .location(URI.create(presignedUrl))
+            .build();
+}
+```
+
+- 실제 적용 시에는 소유권 검증, `type=preview` 분기 등은 기존 `StorageCommandService`/`PresignedUrlService`와 맞춰 구성하면 됩니다.
+
+---
+
+## 6. 참고 (AWS 문서)
+
+- [Authenticating Requests: Using Query Parameters (SigV4)](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html)  
+  - X-Amz-Date, X-Amz-Expires 형식 및 유효성 검사 기준
+- [Troubleshooting S3 presigned URL 403 / SignatureDoesNotMatch](https://repost.aws/knowledge-center/s3-presigned-url-signature-mismatch)  
+  - 시계 동기화, 리전/버킷/키 일치 등 점검 항목

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/controller/production/ProductionController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/controller/production/ProductionController.java
@@ -8,25 +8,28 @@ import org.example.sharedprompts.domain.auth.CurrentUser;
 import org.example.sharedprompts.dto.common.CustomResponse;
 import org.example.sharedprompts.dto.common.CustomResponseHelper;
 import org.example.sharedprompts.module.domain.production.application.ProductionApplicationService;
-import org.example.sharedprompts.module.dto.request.production.*;
+import org.example.sharedprompts.module.dto.request.production.BlogProductionRequestDto;
+import org.example.sharedprompts.module.dto.request.production.DocumentProductionRequestDto;
+import org.example.sharedprompts.module.dto.request.production.EmailProductionRequestDto;
+import org.example.sharedprompts.module.dto.request.production.ImageProductionRequestDto;
+import org.example.sharedprompts.module.dto.request.production.LiteraryProductionRequestDto;
+import org.example.sharedprompts.module.dto.request.production.TextProductionRequestDto;
 import org.example.sharedprompts.module.dto.response.production.JobResponseDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 통합 Production Controller
- */
 @RestController
 @RequestMapping("/prompts/{promptId}/production")
 @RequiredArgsConstructor
 @Slf4j
 public class ProductionController {
-    
+
     private final ProductionApplicationService applicationService;
-    
-    /**
-     * Text Production 생성 요청
-     */
+
     @PostMapping("/text")
     public ResponseEntity<CustomResponse<JobResponseDto>> produceText(
             @PathVariable Long promptId,
@@ -44,10 +47,7 @@ public class ProductionController {
         
         return CustomResponseHelper.ok(response);
     }
-    
-    /**
-     * Image Production 생성 요청
-     */
+
     @PostMapping("/image")
     public ResponseEntity<CustomResponse<JobResponseDto>> produceImage(
             @PathVariable Long promptId,
@@ -65,10 +65,7 @@ public class ProductionController {
         
         return CustomResponseHelper.ok(response);
     }
-    
-    /**
-     * Email Production 생성 요청
-     */
+
     @PostMapping("/email")
     public ResponseEntity<CustomResponse<JobResponseDto>> produceEmail(
             @PathVariable Long promptId,
@@ -86,10 +83,7 @@ public class ProductionController {
         
         return CustomResponseHelper.ok(response);
     }
-    
-    /**
-     * Blog Production 생성 요청
-     */
+
     @PostMapping("/blog")
     public ResponseEntity<CustomResponse<JobResponseDto>> produceBlog(
             @PathVariable Long promptId,
@@ -107,10 +101,7 @@ public class ProductionController {
         
         return CustomResponseHelper.ok(response);
     }
-    
-    /**
-     * Document Production 생성 요청
-     */
+
     @PostMapping("/document")
     public ResponseEntity<CustomResponse<JobResponseDto>> produceDocument(
             @PathVariable Long promptId,
@@ -126,6 +117,22 @@ public class ProductionController {
                 request
         );
         
+        return CustomResponseHelper.ok(response);
+    }
+
+    @PostMapping("/literary")
+    public ResponseEntity<CustomResponse<JobResponseDto>> produceLiterary(
+            @PathVariable Long promptId,
+            @Valid @RequestBody LiteraryProductionRequestDto request,
+            @CurrentUser AuthUser authUser
+    ) {
+        log.info("Literary production requested - promptId: {}, userId: {}, literaryType: {}",
+                promptId, authUser.getId(), request.literaryType());
+        JobResponseDto response = applicationService.produce(
+                promptId,
+                authUser.getId(),
+                request
+        );
         return CustomResponseHelper.ok(response);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/application/factory/impl/LiteraryCommandFactory.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/application/factory/impl/LiteraryCommandFactory.java
@@ -4,33 +4,33 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.application.factory.ProductionCommandFactory;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommand;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
-import org.example.sharedprompts.module.domain.production.model.executor.text.TextCommand;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.dto.request.production.LiteraryProductionRequestDto;
 import org.example.sharedprompts.module.dto.request.production.ProductionRequest;
-import org.example.sharedprompts.module.dto.request.production.TextProductionRequestDto;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class TextCommandFactory implements ProductionCommandFactory {
+public class LiteraryCommandFactory implements ProductionCommandFactory {
 
     @Override
     public ProductionCommandType getSupportedCommandType() {
-        return ProductionCommandType.TEXT;
+        return ProductionCommandType.LITERARY;
     }
-    
+
     @Override
     public Class<? extends ProductionRequest> getSupportedRequestType() {
-        return TextProductionRequestDto.class;
+        return LiteraryProductionRequestDto.class;
     }
-    
+
     @Override
     public ProductionCommand createCommand(ProductionRequest request) {
-        if (!(request instanceof TextProductionRequestDto)) {
+        if (!(request instanceof LiteraryProductionRequestDto literaryRequest)) {
             throw new IllegalArgumentException(
-                    "Expected TextProductionRequestDto, but got: " +
-                    (request != null ? request.getClass().getName() : "null"));
+                    "Expected LiteraryProductionRequestDto, but got: " +
+                            (request != null ? request.getClass().getName() : "null"));
         }
-        log.debug("Creating TextCommand from request (using default fileName/format)");
-        return new TextCommand("output", "txt");
+        log.debug("Creating LiteraryCommand from request - literaryType: {}", literaryRequest.literaryType());
+        return new LiteraryCommand(literaryRequest.literaryType());
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/contract/command/ProductionCommandType.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/contract/command/ProductionCommandType.java
@@ -1,6 +1,6 @@
 package org.example.sharedprompts.module.domain.production.model.contract.command;
 
 public enum ProductionCommandType {
-    TEXT, EMAIL, BLOG, IMAGE, DOCUMENT
+    TEXT, EMAIL, BLOG, IMAGE, DOCUMENT, LITERARY
 }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/executor/literary/LiteraryCommand.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/executor/literary/LiteraryCommand.java
@@ -8,6 +8,11 @@ import org.example.sharedprompts.module.domain.production.model.literary.Literar
 
 import java.util.UUID;
 
+/**
+ * Literary production command. The {@code commandId} is a one-time identifier regenerated
+ * on each deserialization (e.g. for request correlation); do not use it for persistence
+ * or idempotency—use job-level idempotency keys instead.
+ */
 public record LiteraryCommand(
         @JsonIgnore String commandId,
         LiteraryType literaryType

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/executor/literary/LiteraryCommand.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/executor/literary/LiteraryCommand.java
@@ -1,0 +1,33 @@
+package org.example.sharedprompts.module.domain.production.model.executor.literary;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommand;
+import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+
+import java.util.UUID;
+
+public record LiteraryCommand(
+        @JsonIgnore String commandId,
+        LiteraryType literaryType
+) implements ProductionCommand {
+
+    public LiteraryCommand(LiteraryType literaryType) {
+        this(UUID.randomUUID().toString(), literaryType);
+    }
+
+    @Override
+    public ProductionCommandType getCommandType() {
+        return ProductionCommandType.LITERARY;
+    }
+
+    @Override
+    public String getCommandId() {
+        return commandId;
+    }
+
+    @Override
+    public String getOutputFormat() {
+        return "literary";
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/executor/literary/LiteraryCommand.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/executor/literary/LiteraryCommand.java
@@ -1,5 +1,6 @@
 package org.example.sharedprompts.module.domain.production.model.executor.literary;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommand;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
@@ -12,6 +13,7 @@ public record LiteraryCommand(
         LiteraryType literaryType
 ) implements ProductionCommand {
 
+    @JsonCreator
     public LiteraryCommand(LiteraryType literaryType) {
         this(UUID.randomUUID().toString(), literaryType);
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/literary/LiteraryFormat.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/literary/LiteraryFormat.java
@@ -1,0 +1,10 @@
+package org.example.sharedprompts.module.domain.production.model.literary;
+
+/**
+ * Supported output format for literary production requests.
+ * Used to constrain allowed values and avoid runtime errors from unsupported format strings.
+ */
+public enum LiteraryFormat {
+    /** Standard literary output (txt, html, pdf pipeline). */
+    STANDARD
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/literary/LiteraryType.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/model/literary/LiteraryType.java
@@ -1,0 +1,8 @@
+package org.example.sharedprompts.module.domain.production.model.literary;
+
+public enum LiteraryType {
+    POEM,
+    SHORT_STORY,
+    NOVEL,
+    SCRIPT
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/JobStateService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/JobStateService.java
@@ -61,12 +61,23 @@ public class JobStateService {
         }
 
         var artifact = productionArtifactService.createArtifact(job, s3Key);
-        String artifactId = artifact.getId().toString();
+        completeJobWithArtifact(jobId, job, artifact.getId().toString());
+    }
 
+    /**
+     * LITERARY 완성 작품: 3개 S3 키(original, preview, pdf)로 아티팩트 생성 후 Job 완료.
+     */
+    public void markStoredLiterary(String jobId, String originalTxtKey, String previewHtmlKey, String finalPdfKey) {
+        JobEntity job = getJob(jobId);
+        var artifact = productionArtifactService.createArtifactForLiterary(
+                job, originalTxtKey, previewHtmlKey, finalPdfKey);
+        completeJobWithArtifact(jobId, job, artifact.getId().toString());
+        log.info("Literary artifact created and job completed - jobId: {}, artifactId: {}", jobId, artifact.getId());
+    }
+
+    private void completeJobWithArtifact(String jobId, JobEntity job, String artifactId) {
         try {
             jobUpdateHelper.updateJob(jobId, jobEntity -> stateMachine.complete(jobEntity, artifactId));
-            log.info("ProductionArtifact created and job completed - jobId: {}, artifactId: {}, s3Key: {}",
-                    jobId, artifactId, s3Key);
         } catch (Exception e) {
             log.error("Failed to complete job after artifact creation - jobId: {}, artifactId: {}. Cleaning up orphaned artifact.",
                     jobId, artifactId, e);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/JobStateService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/JobStateService.java
@@ -68,6 +68,12 @@ public class JobStateService {
      * LITERARY 완성 작품: 3개 S3 키(original, preview, pdf)로 아티팩트 생성 후 Job 완료.
      */
     public void markStoredLiterary(String jobId, String originalTxtKey, String previewHtmlKey, String finalPdfKey) {
+        if (originalTxtKey == null || originalTxtKey.isBlank()
+                || previewHtmlKey == null || previewHtmlKey.isBlank()
+                || finalPdfKey == null || finalPdfKey.isBlank()) {
+            throw new JobProcessingException(ModuleErrorCode.JOB_INVALID_STATUS,
+                    "Literary artifact S3 keys must not be blank - jobId: " + jobId);
+        }
         JobEntity job = getJob(jobId);
         var artifact = productionArtifactService.createArtifactForLiterary(
                 job, originalTxtKey, previewHtmlKey, finalPdfKey);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
@@ -168,6 +168,9 @@ public class JobProcessorDelegate {
         List<String> tokenUsages = new ArrayList<>();
         for (int attempt = 0; attempt <= LITERARY_VALIDATION_MAX_RETRIES; attempt++) {
             execResult = strategy.generate(job, command, composedPrompt, literaryAIExecutor, literaryResponseExtractor);
+            if (execResult == null) {
+                throw new ContentRenderException("Literary generation produced no result");
+            }
             if (execResult.tokenUsage() != null && !execResult.tokenUsage().isBlank()) {
                 tokenUsages.add(execResult.tokenUsage());
             }
@@ -183,7 +186,7 @@ public class JobProcessorDelegate {
 
         LiteraryExecutionResult resultToStore = Objects.requireNonNull(execResult, "Literary generation produced no result");
         String accumulatedTokenUsage = tokenUsages.isEmpty()
-                ? resultToStore.tokenUsage()
+                ? null
                 : String.join("; ", tokenUsages);
         jobStateService.setModelInfo(job.getJobId(), resultToStore.modelName(), accumulatedTokenUsage);
         LiteraryPipelineResult pipelineResult = literaryOutputPipeline.run(resultToStore.content(), job);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
@@ -22,7 +22,9 @@ import org.example.sharedprompts.module.domain.production.service.job.process.ex
 import org.example.sharedprompts.module.domain.production.service.job.process.util.CommandDeserializer;
 import org.example.sharedprompts.module.domain.production.service.job.process.util.FileNameGenerator;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryExecutionResult;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategyRegistry;
 import org.example.sharedprompts.module.domain.production.service.literary.pipeline.LiteraryOutputPipeline;
 import org.example.sharedprompts.module.domain.production.service.literary.pipeline.LiteraryPipelineResult;
@@ -35,6 +37,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 
 @Component
@@ -59,6 +62,7 @@ public class JobProcessorDelegate {
     private final LiteraryValidatorRegistry literaryValidatorRegistry;
     private final LiteraryOutputPipeline literaryOutputPipeline;
     private final LiteraryAIExecutor literaryAIExecutor;
+    private final LiteraryResponseExtractor literaryResponseExtractor;
 
     public void processJob(String jobId) {
         Instant startTime = Instant.now();
@@ -108,7 +112,10 @@ public class JobProcessorDelegate {
             jobStateService.updateJobPromptVersion(job.getJobId(), mergedPrompt.version());
 
             if (command.getCommandType() == ProductionCommandType.LITERARY) {
-                processLiteraryJob(jobId, job, (LiteraryCommand) command, mergedPrompt.content(), startTime, commandType);
+                if (!(command instanceof LiteraryCommand literaryCommand)) {
+                    throw new IllegalStateException("LITERARY command type but deserialized as " + command.getClass().getSimpleName());
+                }
+                processLiteraryJob(jobId, job, literaryCommand, mergedPrompt.content(), startTime, commandType);
                 return;
             }
 
@@ -155,10 +162,10 @@ public class JobProcessorDelegate {
         LiteraryGenerationStrategy strategy = literaryStrategyRegistry.getStrategy(command.literaryType());
         var validator = literaryValidatorRegistry.getValidator(command.literaryType());
 
-        String content = null;
+        LiteraryExecutionResult execResult = null;
         for (int attempt = 0; attempt <= LITERARY_VALIDATION_MAX_RETRIES; attempt++) {
-            content = strategy.generate(job, command, composedPrompt, literaryAIExecutor);
-            LiteraryValidationResult result = validator.validate(content);
+            execResult = strategy.generate(job, command, composedPrompt, literaryAIExecutor, literaryResponseExtractor);
+            LiteraryValidationResult result = validator.validate(execResult.content());
             if (result.isValid()) {
                 break;
             }
@@ -168,7 +175,9 @@ public class JobProcessorDelegate {
             }
         }
 
-        LiteraryPipelineResult pipelineResult = literaryOutputPipeline.run(content, job);
+        LiteraryExecutionResult resultToStore = Objects.requireNonNull(execResult, "Literary generation produced no result");
+        jobStateService.setModelInfo(job.getJobId(), resultToStore.modelName(), resultToStore.tokenUsage());
+        LiteraryPipelineResult pipelineResult = literaryOutputPipeline.run(resultToStore.content(), job);
         jobStateService.markStoredLiterary(
                 job.getJobId(),
                 pipelineResult.getOriginalTxtKey(),

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
@@ -37,6 +37,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -63,6 +65,8 @@ public class JobProcessorDelegate {
     private final LiteraryOutputPipeline literaryOutputPipeline;
     private final LiteraryAIExecutor literaryAIExecutor;
     private final LiteraryResponseExtractor literaryResponseExtractor;
+
+    private static final int LITERARY_VALIDATION_MAX_RETRIES = 2;
 
     public void processJob(String jobId) {
         Instant startTime = Instant.now();
@@ -155,16 +159,18 @@ public class JobProcessorDelegate {
         }
     }
 
-    private static final int LITERARY_VALIDATION_MAX_RETRIES = 2;
-
     private void processLiteraryJob(String jobId, JobEntity job, LiteraryCommand command, String composedPrompt,
                                     Instant startTime, String commandType) {
         LiteraryGenerationStrategy strategy = literaryStrategyRegistry.getStrategy(command.literaryType());
         var validator = literaryValidatorRegistry.getValidator(command.literaryType());
 
         LiteraryExecutionResult execResult = null;
+        List<String> tokenUsages = new ArrayList<>();
         for (int attempt = 0; attempt <= LITERARY_VALIDATION_MAX_RETRIES; attempt++) {
             execResult = strategy.generate(job, command, composedPrompt, literaryAIExecutor, literaryResponseExtractor);
+            if (execResult.tokenUsage() != null && !execResult.tokenUsage().isBlank()) {
+                tokenUsages.add(execResult.tokenUsage());
+            }
             LiteraryValidationResult result = validator.validate(execResult.content());
             if (result.isValid()) {
                 break;
@@ -176,7 +182,10 @@ public class JobProcessorDelegate {
         }
 
         LiteraryExecutionResult resultToStore = Objects.requireNonNull(execResult, "Literary generation produced no result");
-        jobStateService.setModelInfo(job.getJobId(), resultToStore.modelName(), resultToStore.tokenUsage());
+        String accumulatedTokenUsage = tokenUsages.isEmpty()
+                ? resultToStore.tokenUsage()
+                : String.join("; ", tokenUsages);
+        jobStateService.setModelInfo(job.getJobId(), resultToStore.modelName(), accumulatedTokenUsage);
         LiteraryPipelineResult pipelineResult = literaryOutputPipeline.run(resultToStore.content(), job);
         jobStateService.markStoredLiterary(
                 job.getJobId(),

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/JobProcessorDelegate.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommand;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.service.job.JobLockService;
 import org.example.sharedprompts.module.domain.production.service.job.JobStateService;
 import org.example.sharedprompts.module.domain.production.service.job.gate.JobGateLockService;
@@ -20,6 +21,13 @@ import org.example.sharedprompts.module.domain.production.service.job.process.ex
 import org.example.sharedprompts.module.domain.production.service.job.process.execution.content.ContentStorageService;
 import org.example.sharedprompts.module.domain.production.service.job.process.util.CommandDeserializer;
 import org.example.sharedprompts.module.domain.production.service.job.process.util.FileNameGenerator;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategyRegistry;
+import org.example.sharedprompts.module.domain.production.service.literary.pipeline.LiteraryOutputPipeline;
+import org.example.sharedprompts.module.domain.production.service.literary.pipeline.LiteraryPipelineResult;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidatorRegistry;
 import org.example.sharedprompts.module.domain.production.service.parser.ParsedResponse;
 import org.example.sharedprompts.module.domain.production.service.prompt.PromptTemplateService;
 import org.example.sharedprompts.module.domain.production.util.TenantContextValidator;
@@ -47,10 +55,11 @@ public class JobProcessorDelegate {
     private final FileNameGenerator fileNameGenerator;
     private final JobMetrics jobMetrics;
     private final Optional<JobGateLockService> jobGateLockService;
+    private final LiteraryGenerationStrategyRegistry literaryStrategyRegistry;
+    private final LiteraryValidatorRegistry literaryValidatorRegistry;
+    private final LiteraryOutputPipeline literaryOutputPipeline;
+    private final LiteraryAIExecutor literaryAIExecutor;
 
-    /**
-     * Job 처리 실행
-     */
     public void processJob(String jobId) {
         Instant startTime = Instant.now();
 
@@ -68,13 +77,7 @@ public class JobProcessorDelegate {
             return;
         }
 
-        // Ensure tenant context is set at the beginning of async processing
-        // In multi-tenant SaaS, tenant_id is REQUIRED for all operations
-        // tenant_id must come from TenantContext (set by SecurityContextTaskDecorator from X-Tenant-Id header)
-        // DO NOT create or generate tenant_id - it must be provided in the request header
         String tenantId = TenantContextValidator.requireTenantContextForJob(jobId);
-
-        // Gate Lock: 외부 호출(AI/S3) 중복 방지. 획득 실패 시 재큐를 위해 처리하지 않고 반환 (DEPLOYMENT_ISSUES 4.1)
         boolean gateLockAcquired = jobGateLockService
                 .map(s -> s.tryLock(tenantId, jobId))
                 .orElse(true);
@@ -98,36 +101,34 @@ public class JobProcessorDelegate {
             var mergedPrompt = promptTemplateService.mergePrompt(
                     job.getPromptId(),
                     job.getUserId(),
-                    command.getCommandType(),
+                    command,
                     job.getUserInput()
             );
 
             jobStateService.updateJobPromptVersion(job.getJobId(), mergedPrompt.version());
 
+            if (command.getCommandType() == ProductionCommandType.LITERARY) {
+                processLiteraryJob(jobId, job, (LiteraryCommand) command, mergedPrompt.content(), startTime, commandType);
+                return;
+            }
+
             AIJobExecutor.AIExecutionResult aiResult = aiJobExecutor.execute(job, command, mergedPrompt.content());
-            // AI 모델 정보 설정
             jobStateService.setModelInfo(job.getJobId(), aiResult.modelName(), aiResult.tokenUsage());
 
             ParsedResponse parsedResponse = aiResponseHandler.parse(aiResult.rawResponse(), command.getCommandType());
             String renderedContent = contentRenderer.render(parsedResponse.jsonNode(), command.getCommandType());
 
             String s3Key;
-            
-            // 이미지 생성인 경우 이미 저장된 PNG 파일 경로를 그대로 사용
             if (command.getCommandType() == ProductionCommandType.IMAGE) {
-                // ImageRenderer가 이미지 경로를 그대로 반환하므로 그대로 사용
                 s3Key = renderedContent;
                 log.info("Using existing image path for IMAGE command - s3Key: {}", s3Key);
             } else {
-                // 다른 타입은 기존 로직대로 포맷 변환 후 저장
                 String outputFormat = command.getOutputFormat();
                 String baseFileName = fileNameGenerator.generate(command);
                 var converted = contentFormatter.format(renderedContent, outputFormat, baseFileName);
                 s3Key = contentStorageService.store(converted.data(), converted.contentType(), job, converted.fileName());
             }
-            
             jobStateService.markStored(job.getJobId(), s3Key);
-            // markStored() 내부에서 이미 complete()를 호출하므로 중복 호출 제거
 
             Duration duration = Duration.between(startTime, Instant.now());
             jobMetrics.recordJobCompleted(commandType, duration);
@@ -146,5 +147,37 @@ public class JobProcessorDelegate {
             throw e;
         }
     }
-}
 
+    private static final int LITERARY_VALIDATION_MAX_RETRIES = 2;
+
+    private void processLiteraryJob(String jobId, JobEntity job, LiteraryCommand command, String composedPrompt,
+                                    Instant startTime, String commandType) {
+        LiteraryGenerationStrategy strategy = literaryStrategyRegistry.getStrategy(command.literaryType());
+        var validator = literaryValidatorRegistry.getValidator(command.literaryType());
+
+        String content = null;
+        for (int attempt = 0; attempt <= LITERARY_VALIDATION_MAX_RETRIES; attempt++) {
+            content = strategy.generate(job, command, composedPrompt, literaryAIExecutor);
+            LiteraryValidationResult result = validator.validate(content);
+            if (result.isValid()) {
+                break;
+            }
+            log.warn("Literary validation failed - jobId: {}, attempt: {}, errors: {}", jobId, attempt + 1, result.getErrors());
+            if (attempt == LITERARY_VALIDATION_MAX_RETRIES) {
+                throw new ContentRenderException("Literary output validation failed after " + (LITERARY_VALIDATION_MAX_RETRIES + 1) + " attempts: " + result.getErrors());
+            }
+        }
+
+        LiteraryPipelineResult pipelineResult = literaryOutputPipeline.run(content, job);
+        jobStateService.markStoredLiterary(
+                job.getJobId(),
+                pipelineResult.getOriginalTxtKey(),
+                pipelineResult.getPreviewHtmlKey(),
+                pipelineResult.getFinalPdfKey()
+        );
+
+        Duration duration = Duration.between(startTime, Instant.now());
+        jobMetrics.recordJobCompleted(commandType, duration);
+        log.info("Literary job completed - jobId: {}, duration: {}ms", jobId, duration.toMillis());
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/execution/ai/builder/AIRequestBuilder.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/execution/ai/builder/AIRequestBuilder.java
@@ -5,6 +5,7 @@ import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.model.ai.AIContentRequest;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommand;
 import org.example.sharedprompts.module.domain.production.model.executor.image.ImageCommand;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.model.executor.text.TextCommand;
 import org.example.sharedprompts.module.domain.production.service.ai.ContentType;
 import org.springframework.stereotype.Component;
@@ -28,6 +29,8 @@ public class AIRequestBuilder {
 
         if (command instanceof TextCommand textCommand) {
             builder.contentTypeHint(textCommand.format());
+        } else if (command instanceof LiteraryCommand literaryCommand) {
+            builder.contentTypeHint("literary:" + literaryCommand.literaryType().name());
         } else if (command instanceof ImageCommand imageCommand) {
             builder
                     .width(imageCommand.width())

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/execution/ai/builder/AIRequestBuilder.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/execution/ai/builder/AIRequestBuilder.java
@@ -30,7 +30,7 @@ public class AIRequestBuilder {
         if (command instanceof TextCommand textCommand) {
             builder.contentTypeHint(textCommand.format());
         } else if (command instanceof LiteraryCommand literaryCommand) {
-            builder.contentTypeHint("literary:" + literaryCommand.literaryType().name());
+            builder.contentTypeHint("literary:" + Objects.requireNonNull(literaryCommand.literaryType(), "literaryType must not be null").name());
         } else if (command instanceof ImageCommand imageCommand) {
             builder
                     .width(imageCommand.width())

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/CommandDeserializer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/CommandDeserializer.java
@@ -10,6 +10,7 @@ import org.example.sharedprompts.module.domain.production.model.executor.email.E
 import org.example.sharedprompts.module.domain.production.model.executor.image.ImageCommand;
 import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.model.executor.text.TextCommand;
+import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,14 +30,19 @@ public class CommandDeserializer {
     }
 
     private Class<? extends ProductionCommand> getCommandClass(String commandType) {
-        return switch (commandType) {
-            case "TEXT" -> TextCommand.class;
-            case "IMAGE" -> ImageCommand.class;
-            case "EMAIL" -> EmailCommand.class;
-            case "BLOG" -> BlogCommand.class;
-            case "DOCUMENT" -> DocumentCommand.class;
-            case "LITERARY" -> LiteraryCommand.class;
-            default -> throw new IllegalArgumentException("Unknown command type: " + commandType);
+        ProductionCommandType type;
+        try {
+            type = ProductionCommandType.valueOf(commandType);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown command type: " + commandType, e);
+        }
+        return switch (type) {
+            case TEXT -> TextCommand.class;
+            case IMAGE -> ImageCommand.class;
+            case EMAIL -> EmailCommand.class;
+            case BLOG -> BlogCommand.class;
+            case DOCUMENT -> DocumentCommand.class;
+            case LITERARY -> LiteraryCommand.class;
         };
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/CommandDeserializer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/CommandDeserializer.java
@@ -30,6 +30,9 @@ public class CommandDeserializer {
     }
 
     private Class<? extends ProductionCommand> getCommandClass(String commandType) {
+        if (commandType == null) {
+            throw new IllegalArgumentException("Command type must not be null");
+        }
         ProductionCommandType type;
         try {
             type = ProductionCommandType.valueOf(commandType);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/CommandDeserializer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/CommandDeserializer.java
@@ -8,6 +8,7 @@ import org.example.sharedprompts.module.domain.production.model.executor.blog.Bl
 import org.example.sharedprompts.module.domain.production.model.executor.document.DocumentCommand;
 import org.example.sharedprompts.module.domain.production.model.executor.email.EmailCommand;
 import org.example.sharedprompts.module.domain.production.model.executor.image.ImageCommand;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.model.executor.text.TextCommand;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +35,7 @@ public class CommandDeserializer {
             case "EMAIL" -> EmailCommand.class;
             case "BLOG" -> BlogCommand.class;
             case "DOCUMENT" -> DocumentCommand.class;
+            case "LITERARY" -> LiteraryCommand.class;
             default -> throw new IllegalArgumentException("Unknown command type: " + commandType);
         };
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/ContentTypeDeterminer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/job/process/util/ContentTypeDeterminer.java
@@ -11,7 +11,7 @@ public class ContentTypeDeterminer {
     public ContentType determine(ProductionCommand command) {
         ProductionCommandType commandType = command.getCommandType();
         return switch (commandType) {
-            case TEXT, EMAIL, BLOG, DOCUMENT -> ContentType.TEXT;
+            case TEXT, EMAIL, BLOG, DOCUMENT, LITERARY -> ContentType.TEXT;
             case IMAGE -> ContentType.IMAGE;
         };
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutor.java
@@ -5,5 +5,5 @@ import org.example.sharedprompts.module.domain.production.model.executor.literar
 
 public interface LiteraryAIExecutor {
 
-    String execute(JobEntity job, LiteraryCommand command, String prompt);
+    LiteraryExecutionResult execute(JobEntity job, LiteraryCommand command, String prompt);
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutor.java
@@ -1,0 +1,9 @@
+package org.example.sharedprompts.module.domain.production.service.literary;
+
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+
+public interface LiteraryAIExecutor {
+
+    String execute(JobEntity job, LiteraryCommand command, String prompt);
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutorImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutorImpl.java
@@ -1,0 +1,26 @@
+package org.example.sharedprompts.module.domain.production.service.literary;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.domain.production.service.job.process.execution.ai.AIJobExecutor;
+import org.example.sharedprompts.module.domain.production.service.job.process.exception.AIServiceException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LiteraryAIExecutorImpl implements LiteraryAIExecutor {
+
+    private final AIJobExecutor aiJobExecutor;
+
+    @Override
+    public String execute(JobEntity job, LiteraryCommand command, String prompt) {
+        var result = aiJobExecutor.execute(job, command, prompt);
+        if (result == null || result.rawResponse() == null) {
+            throw new AIServiceException("AI returned null or empty response");
+        }
+        return result.rawResponse();
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutorImpl.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryAIExecutorImpl.java
@@ -16,11 +16,15 @@ public class LiteraryAIExecutorImpl implements LiteraryAIExecutor {
     private final AIJobExecutor aiJobExecutor;
 
     @Override
-    public String execute(JobEntity job, LiteraryCommand command, String prompt) {
+    public LiteraryExecutionResult execute(JobEntity job, LiteraryCommand command, String prompt) {
         var result = aiJobExecutor.execute(job, command, prompt);
-        if (result == null || result.rawResponse() == null) {
+        if (result == null || result.rawResponse() == null || result.rawResponse().isBlank()) {
             throw new AIServiceException("AI returned null or empty response");
         }
-        return result.rawResponse();
+        return new LiteraryExecutionResult(
+                result.rawResponse(),
+                result.modelName(),
+                result.tokenUsage() != null ? result.tokenUsage() : ""
+        );
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryExecutionResult.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryExecutionResult.java
@@ -1,0 +1,10 @@
+package org.example.sharedprompts.module.domain.production.service.literary;
+
+/**
+ * Result of a literary AI execution, including content and model observability data.
+ */
+public record LiteraryExecutionResult(
+        String content,
+        String modelName,
+        String tokenUsage
+) {}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategy.java
@@ -1,0 +1,12 @@
+package org.example.sharedprompts.module.domain.production.service.literary;
+
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+
+public interface LiteraryGenerationStrategy {
+
+    LiteraryType getLiteraryType();
+
+    String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor);
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategy.java
@@ -8,5 +8,14 @@ public interface LiteraryGenerationStrategy {
 
     LiteraryType getLiteraryType();
 
-    String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor);
+    /**
+     * Generate literary content. Default implementation: execute AI, then extract content.
+     * Override for type-specific logic (e.g. novel chapter planning).
+     */
+    default LiteraryExecutionResult generate(JobEntity job, LiteraryCommand command, String composedPrompt,
+                                             LiteraryAIExecutor aiExecutor, LiteraryResponseExtractor responseExtractor) {
+        LiteraryExecutionResult execResult = aiExecutor.execute(job, command, composedPrompt);
+        String content = responseExtractor.extractContent(execResult.content());
+        return new LiteraryExecutionResult(content, execResult.modelName(), execResult.tokenUsage());
+    }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
@@ -4,19 +4,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 @Slf4j
 public class LiteraryGenerationStrategyRegistry {
 
-    private final Map<LiteraryType, LiteraryGenerationStrategy> strategyMap = new ConcurrentHashMap<>();
+    private final Map<LiteraryType, LiteraryGenerationStrategy> strategyMap;
 
     public LiteraryGenerationStrategyRegistry(List<LiteraryGenerationStrategy> strategies) {
+        Map<LiteraryType, LiteraryGenerationStrategy> map = new EnumMap<>(LiteraryType.class);
         for (LiteraryGenerationStrategy strategy : strategies) {
-            LiteraryGenerationStrategy existing = strategyMap.put(strategy.getLiteraryType(), strategy);
+            LiteraryGenerationStrategy existing = map.put(strategy.getLiteraryType(), strategy);
             if (existing != null) {
                 throw new IllegalStateException(
                         "Duplicate LiteraryGenerationStrategy for type " + strategy.getLiteraryType()
@@ -24,6 +26,7 @@ public class LiteraryGenerationStrategyRegistry {
             }
             log.info("Registered LiteraryGenerationStrategy: {} for {}", strategy.getClass().getSimpleName(), strategy.getLiteraryType());
         }
+        this.strategyMap = Collections.unmodifiableMap(map);
     }
 
     public LiteraryGenerationStrategy getStrategy(LiteraryType literaryType) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
@@ -1,0 +1,31 @@
+package org.example.sharedprompts.module.domain.production.service.literary;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Slf4j
+public class LiteraryGenerationStrategyRegistry {
+
+    private final Map<LiteraryType, LiteraryGenerationStrategy> strategyMap = new ConcurrentHashMap<>();
+
+    public LiteraryGenerationStrategyRegistry(List<LiteraryGenerationStrategy> strategies) {
+        for (LiteraryGenerationStrategy strategy : strategies) {
+            strategyMap.put(strategy.getLiteraryType(), strategy);
+            log.info("Registered LiteraryGenerationStrategy: {} for {}", strategy.getClass().getSimpleName(), strategy.getLiteraryType());
+        }
+    }
+
+    public LiteraryGenerationStrategy getStrategy(LiteraryType literaryType) {
+        LiteraryGenerationStrategy strategy = strategyMap.get(literaryType);
+        if (strategy == null) {
+            throw new IllegalArgumentException("No LiteraryGenerationStrategy for type: " + literaryType);
+        }
+        return strategy;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
@@ -30,6 +30,9 @@ public class LiteraryGenerationStrategyRegistry {
     }
 
     public LiteraryGenerationStrategy getStrategy(LiteraryType literaryType) {
+        if (literaryType == null) {
+            throw new IllegalArgumentException("literaryType must not be null");
+        }
         LiteraryGenerationStrategy strategy = strategyMap.get(literaryType);
         if (strategy == null) {
             throw new IllegalArgumentException("No LiteraryGenerationStrategy for type: " + literaryType);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryGenerationStrategyRegistry.java
@@ -16,7 +16,12 @@ public class LiteraryGenerationStrategyRegistry {
 
     public LiteraryGenerationStrategyRegistry(List<LiteraryGenerationStrategy> strategies) {
         for (LiteraryGenerationStrategy strategy : strategies) {
-            strategyMap.put(strategy.getLiteraryType(), strategy);
+            LiteraryGenerationStrategy existing = strategyMap.put(strategy.getLiteraryType(), strategy);
+            if (existing != null) {
+                throw new IllegalStateException(
+                        "Duplicate LiteraryGenerationStrategy for type " + strategy.getLiteraryType()
+                                + ": " + existing.getClass().getSimpleName() + " and " + strategy.getClass().getSimpleName());
+            }
             log.info("Registered LiteraryGenerationStrategy: {} for {}", strategy.getClass().getSimpleName(), strategy.getLiteraryType());
         }
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryResponseExtractor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryResponseExtractor.java
@@ -1,0 +1,33 @@
+package org.example.sharedprompts.module.domain.production.service.literary;
+
+import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
+import org.example.sharedprompts.module.domain.production.service.parser.AIResponseParser;
+import org.example.sharedprompts.module.domain.production.service.parser.ParsedResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LiteraryResponseExtractor {
+
+    private final AIResponseParser aiResponseParser;
+
+    public LiteraryResponseExtractor(AIResponseParser aiResponseParser) {
+        this.aiResponseParser = aiResponseParser;
+    }
+
+    public String extractContent(String rawResponse) {
+        if (rawResponse == null || rawResponse.isBlank()) {
+            return "";
+        }
+        String trimmed = rawResponse.trim();
+        if (trimmed.startsWith("{") && trimmed.contains("content")) {
+            try {
+                ParsedResponse parsed = aiResponseParser.parseResponse(rawResponse, ProductionCommandType.TEXT);
+                if (parsed != null && parsed.jsonNode() != null && parsed.jsonNode().has("content")) {
+                    return parsed.jsonNode().get("content").asText("");
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return trimmed;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryResponseExtractor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/LiteraryResponseExtractor.java
@@ -1,11 +1,13 @@
 package org.example.sharedprompts.module.domain.production.service.literary;
 
+import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
 import org.example.sharedprompts.module.domain.production.service.parser.AIResponseParser;
 import org.example.sharedprompts.module.domain.production.service.parser.ParsedResponse;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class LiteraryResponseExtractor {
 
     private final AIResponseParser aiResponseParser;
@@ -19,13 +21,14 @@ public class LiteraryResponseExtractor {
             return "";
         }
         String trimmed = rawResponse.trim();
-        if (trimmed.startsWith("{") && trimmed.contains("content")) {
+        if (trimmed.startsWith("{") && trimmed.contains("\"content\"")) {
             try {
-                ParsedResponse parsed = aiResponseParser.parseResponse(rawResponse, ProductionCommandType.TEXT);
+                ParsedResponse parsed = aiResponseParser.parseResponse(rawResponse, ProductionCommandType.LITERARY);
                 if (parsed != null && parsed.jsonNode() != null && parsed.jsonNode().has("content")) {
                     return parsed.jsonNode().get("content").asText("");
                 }
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                log.debug("Failed to parse literary AI response as JSON, falling back to raw text: {}", e.getMessage());
             }
         }
         return trimmed;

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
@@ -31,9 +31,10 @@ public class NovelGenerationStrategy implements LiteraryGenerationStrategy {
                                             LiteraryAIExecutor aiExecutor, LiteraryResponseExtractor responseExtractor) {
         LiteraryExecutionResult execResult = aiExecutor.execute(job, command, composedPrompt);
         String content = responseExtractor.extractContent(execResult.content());
-        if (tokenEstimator.estimateTokens(content) > tokenEstimator.getMaxTokensPerRequest()) {
+        int estimatedTokens = tokenEstimator.estimateTokens(content);
+        if (estimatedTokens > tokenEstimator.getMaxTokensPerRequest()) {
             log.warn("Novel content exceeds token limit (estimated: {}, max: {}) - consider chunking in a future iteration",
-                    tokenEstimator.estimateTokens(content), tokenEstimator.getMaxTokensPerRequest());
+                    estimatedTokens, tokenEstimator.getMaxTokensPerRequest());
         }
         return new LiteraryExecutionResult(content, execResult.modelName(), execResult.tokenUsage());
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
@@ -32,9 +32,10 @@ public class NovelGenerationStrategy implements LiteraryGenerationStrategy {
         LiteraryExecutionResult execResult = aiExecutor.execute(job, command, composedPrompt);
         String content = responseExtractor.extractContent(execResult.content());
         int estimatedTokens = tokenEstimator.estimateTokens(content);
-        if (estimatedTokens > tokenEstimator.getMaxTokensPerRequest()) {
-            log.warn("Novel content exceeds token limit (estimated: {}, max: {}) - consider chunking in a future iteration",
-                    estimatedTokens, tokenEstimator.getMaxTokensPerRequest());
+        int maxTokensPerRequest = tokenEstimator.getMaxTokensPerRequest();
+        if (estimatedTokens > maxTokensPerRequest) {
+            log.warn("Novel content exceeds token limit - jobId: {}, estimated: {}, max: {} - consider chunking in a future iteration",
+                    job.getJobId(), estimatedTokens, maxTokensPerRequest);
         }
         return new LiteraryExecutionResult(content, execResult.modelName(), execResult.tokenUsage());
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
@@ -1,22 +1,23 @@
 package org.example.sharedprompts.module.domain.production.service.literary.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
 import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryExecutionResult;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
 import org.example.sharedprompts.module.domain.production.service.literary.novel.TokenEstimator;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class NovelGenerationStrategy implements LiteraryGenerationStrategy {
 
-    private final LiteraryResponseExtractor responseExtractor;
     private final TokenEstimator tokenEstimator;
 
-    public NovelGenerationStrategy(LiteraryResponseExtractor responseExtractor, TokenEstimator tokenEstimator) {
-        this.responseExtractor = responseExtractor;
+    public NovelGenerationStrategy(TokenEstimator tokenEstimator) {
         this.tokenEstimator = tokenEstimator;
     }
 
@@ -26,11 +27,14 @@ public class NovelGenerationStrategy implements LiteraryGenerationStrategy {
     }
 
     @Override
-    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
-        String raw = aiExecutor.execute(job, command, composedPrompt);
-        String content = responseExtractor.extractContent(raw);
+    public LiteraryExecutionResult generate(JobEntity job, LiteraryCommand command, String composedPrompt,
+                                            LiteraryAIExecutor aiExecutor, LiteraryResponseExtractor responseExtractor) {
+        LiteraryExecutionResult execResult = aiExecutor.execute(job, command, composedPrompt);
+        String content = responseExtractor.extractContent(execResult.content());
         if (tokenEstimator.estimateTokens(content) > tokenEstimator.getMaxTokensPerRequest()) {
+            log.warn("Novel content exceeds token limit (estimated: {}, max: {}) - consider chunking in a future iteration",
+                    tokenEstimator.estimateTokens(content), tokenEstimator.getMaxTokensPerRequest());
         }
-        return content;
+        return new LiteraryExecutionResult(content, execResult.modelName(), execResult.tokenUsage());
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/NovelGenerationStrategy.java
@@ -1,0 +1,36 @@
+package org.example.sharedprompts.module.domain.production.service.literary.impl;
+
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
+import org.example.sharedprompts.module.domain.production.service.literary.novel.TokenEstimator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NovelGenerationStrategy implements LiteraryGenerationStrategy {
+
+    private final LiteraryResponseExtractor responseExtractor;
+    private final TokenEstimator tokenEstimator;
+
+    public NovelGenerationStrategy(LiteraryResponseExtractor responseExtractor, TokenEstimator tokenEstimator) {
+        this.responseExtractor = responseExtractor;
+        this.tokenEstimator = tokenEstimator;
+    }
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.NOVEL;
+    }
+
+    @Override
+    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
+        String raw = aiExecutor.execute(job, command, composedPrompt);
+        String content = responseExtractor.extractContent(raw);
+        if (tokenEstimator.estimateTokens(content) > tokenEstimator.getMaxTokensPerRequest()) {
+        }
+        return content;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/PoemGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/PoemGenerationStrategy.java
@@ -1,0 +1,30 @@
+package org.example.sharedprompts.module.domain.production.service.literary.impl;
+
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PoemGenerationStrategy implements LiteraryGenerationStrategy {
+
+    private final LiteraryResponseExtractor responseExtractor;
+
+    public PoemGenerationStrategy(LiteraryResponseExtractor responseExtractor) {
+        this.responseExtractor = responseExtractor;
+    }
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.POEM;
+    }
+
+    @Override
+    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
+        String raw = aiExecutor.execute(job, command, composedPrompt);
+        return responseExtractor.extractContent(raw);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/PoemGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/PoemGenerationStrategy.java
@@ -1,30 +1,14 @@
 package org.example.sharedprompts.module.domain.production.service.literary.impl;
 
-import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
-import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
-import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PoemGenerationStrategy implements LiteraryGenerationStrategy {
 
-    private final LiteraryResponseExtractor responseExtractor;
-
-    public PoemGenerationStrategy(LiteraryResponseExtractor responseExtractor) {
-        this.responseExtractor = responseExtractor;
-    }
-
     @Override
     public LiteraryType getLiteraryType() {
         return LiteraryType.POEM;
-    }
-
-    @Override
-    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
-        String raw = aiExecutor.execute(job, command, composedPrompt);
-        return responseExtractor.extractContent(raw);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ScriptGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ScriptGenerationStrategy.java
@@ -1,30 +1,14 @@
 package org.example.sharedprompts.module.domain.production.service.literary.impl;
 
-import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
-import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
-import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ScriptGenerationStrategy implements LiteraryGenerationStrategy {
 
-    private final LiteraryResponseExtractor responseExtractor;
-
-    public ScriptGenerationStrategy(LiteraryResponseExtractor responseExtractor) {
-        this.responseExtractor = responseExtractor;
-    }
-
     @Override
     public LiteraryType getLiteraryType() {
         return LiteraryType.SCRIPT;
-    }
-
-    @Override
-    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
-        String raw = aiExecutor.execute(job, command, composedPrompt);
-        return responseExtractor.extractContent(raw);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ScriptGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ScriptGenerationStrategy.java
@@ -1,0 +1,30 @@
+package org.example.sharedprompts.module.domain.production.service.literary.impl;
+
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScriptGenerationStrategy implements LiteraryGenerationStrategy {
+
+    private final LiteraryResponseExtractor responseExtractor;
+
+    public ScriptGenerationStrategy(LiteraryResponseExtractor responseExtractor) {
+        this.responseExtractor = responseExtractor;
+    }
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.SCRIPT;
+    }
+
+    @Override
+    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
+        String raw = aiExecutor.execute(job, command, composedPrompt);
+        return responseExtractor.extractContent(raw);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ShortStoryGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ShortStoryGenerationStrategy.java
@@ -1,0 +1,30 @@
+package org.example.sharedprompts.module.domain.production.service.literary.impl;
+
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
+import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShortStoryGenerationStrategy implements LiteraryGenerationStrategy {
+
+    private final LiteraryResponseExtractor responseExtractor;
+
+    public ShortStoryGenerationStrategy(LiteraryResponseExtractor responseExtractor) {
+        this.responseExtractor = responseExtractor;
+    }
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.SHORT_STORY;
+    }
+
+    @Override
+    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
+        String raw = aiExecutor.execute(job, command, composedPrompt);
+        return responseExtractor.extractContent(raw);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ShortStoryGenerationStrategy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/impl/ShortStoryGenerationStrategy.java
@@ -1,30 +1,14 @@
 package org.example.sharedprompts.module.domain.production.service.literary.impl;
 
-import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
-import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.example.sharedprompts.module.domain.production.service.literary.LiteraryAIExecutor;
 import org.example.sharedprompts.module.domain.production.service.literary.LiteraryGenerationStrategy;
-import org.example.sharedprompts.module.domain.production.service.literary.LiteraryResponseExtractor;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ShortStoryGenerationStrategy implements LiteraryGenerationStrategy {
 
-    private final LiteraryResponseExtractor responseExtractor;
-
-    public ShortStoryGenerationStrategy(LiteraryResponseExtractor responseExtractor) {
-        this.responseExtractor = responseExtractor;
-    }
-
     @Override
     public LiteraryType getLiteraryType() {
         return LiteraryType.SHORT_STORY;
-    }
-
-    @Override
-    public String generate(JobEntity job, LiteraryCommand command, String composedPrompt, LiteraryAIExecutor aiExecutor) {
-        String raw = aiExecutor.execute(job, command, composedPrompt);
-        return responseExtractor.extractContent(raw);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterMergeHelper.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterMergeHelper.java
@@ -13,6 +13,9 @@ public final class ChapterMergeHelper {
         if (chapterContents == null || chapterContents.isEmpty()) {
             return "";
         }
-        return String.join(CHAPTER_SEPARATOR, chapterContents);
+        List<String> nonNull = chapterContents.stream()
+                .filter(c -> c != null)
+                .toList();
+        return String.join(CHAPTER_SEPARATOR, nonNull);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterMergeHelper.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterMergeHelper.java
@@ -1,0 +1,18 @@
+package org.example.sharedprompts.module.domain.production.service.literary.novel;
+
+import java.util.List;
+
+public final class ChapterMergeHelper {
+
+    private static final String CHAPTER_SEPARATOR = "\n\n";
+
+    private ChapterMergeHelper() {
+    }
+
+    public static String mergeChapters(List<String> chapterContents) {
+        if (chapterContents == null || chapterContents.isEmpty()) {
+            return "";
+        }
+        return String.join(CHAPTER_SEPARATOR, chapterContents);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterPlan.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterPlan.java
@@ -1,0 +1,15 @@
+package org.example.sharedprompts.module.domain.production.service.literary.novel;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChapterPlan {
+
+    private final int chapterCount;
+    private final List<String> chapterTitlesOrPrompts;
+    private final String userContext;
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterPlan.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/ChapterPlan.java
@@ -3,6 +3,7 @@ package org.example.sharedprompts.module.domain.production.service.literary.nove
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -10,6 +11,7 @@ import java.util.List;
 public class ChapterPlan {
 
     private final int chapterCount;
-    private final List<String> chapterTitlesOrPrompts;
+    @Builder.Default
+    private final List<String> chapterTitlesOrPrompts = Collections.emptyList();
     private final String userContext;
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/TokenEstimator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/TokenEstimator.java
@@ -1,0 +1,28 @@
+package org.example.sharedprompts.module.domain.production.service.literary.novel;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenEstimator {
+
+    private static final int DEFAULT_CHARS_PER_TOKEN = 3;
+
+    @Value("${production.literary.novel.max-tokens-per-request:4000}")
+    private int maxTokensPerRequest = 4000;
+
+    public int estimateTokens(String text) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+        return (text.length() + DEFAULT_CHARS_PER_TOKEN - 1) / DEFAULT_CHARS_PER_TOKEN;
+    }
+
+    public int getMaxTokensPerRequest() {
+        return maxTokensPerRequest;
+    }
+
+    public boolean fitsInSingleRequest(String text) {
+        return estimateTokens(text) <= maxTokensPerRequest;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/TokenEstimator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/novel/TokenEstimator.java
@@ -6,10 +6,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class TokenEstimator {
 
+    /**
+     * Approximate characters per token for estimation only. Actual ratio depends on the AI model's
+     * tokenizer (e.g. BPE). English is often ~4 chars/token; Korean may be ~0.5–1 token per character.
+     * Do not rely on this for precise token limits.
+     */
     private static final int DEFAULT_CHARS_PER_TOKEN = 3;
 
     @Value("${production.literary.novel.max-tokens-per-request:4000}")
-    private int maxTokensPerRequest = 4000;
+    private int maxTokensPerRequest;
 
     public int estimateTokens(String text) {
         if (text == null || text.isBlank()) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/LiteraryOutputPipeline.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/LiteraryOutputPipeline.java
@@ -59,6 +59,6 @@ public class LiteraryOutputPipeline {
 
     private String storePdf(String sanitized, JobEntity job) {
         ConvertedContent converted = formatConverterRegistry.convert(sanitized, "pdf", "final");
-        return contentStorageService.store(converted.data(), converted.contentType(), job, converted.fileName());
+        return contentStorageService.store(converted.data(), converted.contentType(), job, FINAL_PDF);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/LiteraryOutputPipeline.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/LiteraryOutputPipeline.java
@@ -1,0 +1,64 @@
+package org.example.sharedprompts.module.domain.production.service.literary.pipeline;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.service.format.FormatConverterRegistry;
+import org.example.sharedprompts.module.domain.production.service.format.FormatConverterRegistry.ConvertedContent;
+import org.example.sharedprompts.module.domain.production.service.format.markdown.MarkdownToHtmlConverter;
+import org.example.sharedprompts.module.domain.production.service.job.process.execution.content.ContentStorageService;
+import org.example.sharedprompts.module.domain.production.service.job.process.exception.ContentRenderException;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LiteraryOutputPipeline {
+
+    private static final String ORIGINAL_TXT = "original.txt";
+    private static final String PREVIEW_HTML = "preview.html";
+    private static final String FINAL_PDF = "final.pdf";
+
+    private final MarkdownSanitizer markdownSanitizer;
+    private final MarkdownToHtmlConverter markdownToHtmlConverter;
+    private final FormatConverterRegistry formatConverterRegistry;
+    private final ContentStorageService contentStorageService;
+
+    public LiteraryPipelineResult run(String markdownContent, JobEntity job) {
+        String sanitized = markdownSanitizer.sanitize(markdownContent);
+        if (sanitized.isBlank()) {
+            throw new ContentRenderException("Literary content is blank after sanitization");
+        }
+
+        String originalKey = storeOriginal(sanitized, job);
+        String previewKey = storePreview(sanitized, job);
+        String pdfKey = storePdf(sanitized, job);
+
+        log.info("Literary pipeline completed - jobId: {}, original: {}, preview: {}, pdf: {}",
+                job.getJobId(), originalKey, previewKey, pdfKey);
+
+        return LiteraryPipelineResult.builder()
+                .originalTxtKey(originalKey)
+                .previewHtmlKey(previewKey)
+                .finalPdfKey(pdfKey)
+                .build();
+    }
+
+    private String storeOriginal(String sanitized, JobEntity job) {
+        byte[] data = sanitized.getBytes(StandardCharsets.UTF_8);
+        return contentStorageService.store(data, "text/plain", job, ORIGINAL_TXT);
+    }
+
+    private String storePreview(String sanitized, JobEntity job) {
+        String html = markdownToHtmlConverter.convert(sanitized);
+        byte[] data = html.getBytes(StandardCharsets.UTF_8);
+        return contentStorageService.store(data, "text/html", job, PREVIEW_HTML);
+    }
+
+    private String storePdf(String sanitized, JobEntity job) {
+        ConvertedContent converted = formatConverterRegistry.convert(sanitized, "pdf", "final");
+        return contentStorageService.store(converted.data(), converted.contentType(), job, converted.fileName());
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/LiteraryPipelineResult.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/LiteraryPipelineResult.java
@@ -1,0 +1,13 @@
+package org.example.sharedprompts.module.domain.production.service.literary.pipeline;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LiteraryPipelineResult {
+
+    private final String originalTxtKey;
+    private final String previewHtmlKey;
+    private final String finalPdfKey;
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/MarkdownSanitizer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/MarkdownSanitizer.java
@@ -7,9 +7,9 @@ import java.util.regex.Pattern;
 @Component
 public class MarkdownSanitizer {
 
+    // Match only at the very start of the document (no MULTILINE) to avoid stripping mid-document lines
     private static final Pattern EXPLANATION_PREFIX = Pattern.compile(
-            "^(다음과\\s*같이|아래와\\s*같이|다음은|아래는|작성\\s*결과|결과물|출력\\s*내용)[:\\s]*",
-            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
+            "^(다음과\\s*같이|아래와\\s*같이|다음은|아래는|작성\\s*결과|결과물|출력\\s*내용)[:\\s]*"
     );
 
     public String sanitize(String raw) {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/MarkdownSanitizer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/pipeline/MarkdownSanitizer.java
@@ -1,0 +1,23 @@
+package org.example.sharedprompts.module.domain.production.service.literary.pipeline;
+
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class MarkdownSanitizer {
+
+    private static final Pattern EXPLANATION_PREFIX = Pattern.compile(
+            "^(다음과\\s*같이|아래와\\s*같이|다음은|아래는|작성\\s*결과|결과물|출력\\s*내용)[:\\s]*",
+            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE
+    );
+
+    public String sanitize(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "";
+        }
+        String t = raw.trim();
+        t = EXPLANATION_PREFIX.matcher(t).replaceFirst("");
+        return t.trim();
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryOutputValidator.java
@@ -1,0 +1,10 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation;
+
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+
+public interface LiteraryOutputValidator {
+
+    LiteraryType getLiteraryType();
+
+    LiteraryValidationResult validate(String rawContent);
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidationResult.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidationResult.java
@@ -1,0 +1,27 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Builder
+public class LiteraryValidationResult {
+
+    private final boolean valid;
+    @Builder.Default
+    private final List<String> errors = Collections.emptyList();
+
+    public static LiteraryValidationResult ok() {
+        return LiteraryValidationResult.builder().valid(true).build();
+    }
+
+    public static LiteraryValidationResult failure(List<String> errors) {
+        return LiteraryValidationResult.builder()
+                .valid(false)
+                .errors(errors != null ? errors : Collections.emptyList())
+                .build();
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
@@ -1,0 +1,31 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Slf4j
+public class LiteraryValidatorRegistry {
+
+    private final Map<LiteraryType, LiteraryOutputValidator> validatorMap = new ConcurrentHashMap<>();
+
+    public LiteraryValidatorRegistry(List<LiteraryOutputValidator> validators) {
+        for (LiteraryOutputValidator v : validators) {
+            validatorMap.put(v.getLiteraryType(), v);
+            log.info("Registered LiteraryOutputValidator: {} for {}", v.getClass().getSimpleName(), v.getLiteraryType());
+        }
+    }
+
+    public LiteraryOutputValidator getValidator(LiteraryType literaryType) {
+        LiteraryOutputValidator v = validatorMap.get(literaryType);
+        if (v == null) {
+            return validatorMap.get(LiteraryType.POEM);
+        }
+        return v;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
@@ -4,24 +4,35 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 @Slf4j
 public class LiteraryValidatorRegistry {
 
-    private final Map<LiteraryType, LiteraryOutputValidator> validatorMap = new ConcurrentHashMap<>();
+    private final Map<LiteraryType, LiteraryOutputValidator> validatorMap;
 
     public LiteraryValidatorRegistry(List<LiteraryOutputValidator> validators) {
+        Map<LiteraryType, LiteraryOutputValidator> map = new EnumMap<>(LiteraryType.class);
         for (LiteraryOutputValidator v : validators) {
-            validatorMap.put(v.getLiteraryType(), v);
+            LiteraryOutputValidator existing = map.put(v.getLiteraryType(), v);
+            if (existing != null) {
+                throw new IllegalStateException(
+                        "Duplicate LiteraryOutputValidator for type " + v.getLiteraryType()
+                                + ": " + existing.getClass().getSimpleName() + " and " + v.getClass().getSimpleName());
+            }
             log.info("Registered LiteraryOutputValidator: {} for {}", v.getClass().getSimpleName(), v.getLiteraryType());
         }
+        this.validatorMap = Collections.unmodifiableMap(map);
     }
 
     public LiteraryOutputValidator getValidator(LiteraryType literaryType) {
+        if (literaryType == null) {
+            throw new IllegalArgumentException("literaryType must not be null");
+        }
         LiteraryOutputValidator v = validatorMap.get(literaryType);
         if (v == null) {
             throw new IllegalArgumentException("No LiteraryOutputValidator registered for type: " + literaryType);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Component
 @Slf4j
@@ -18,6 +20,10 @@ public class LiteraryValidatorRegistry {
     public LiteraryValidatorRegistry(List<LiteraryOutputValidator> validators) {
         Map<LiteraryType, LiteraryOutputValidator> map = new EnumMap<>(LiteraryType.class);
         for (LiteraryOutputValidator v : validators) {
+            if (v.getLiteraryType() == null) {
+                throw new IllegalStateException(
+                        "getLiteraryType() returned null for " + v.getClass().getSimpleName());
+            }
             LiteraryOutputValidator existing = map.put(v.getLiteraryType(), v);
             if (existing != null) {
                 throw new IllegalStateException(
@@ -25,6 +31,12 @@ public class LiteraryValidatorRegistry {
                                 + ": " + existing.getClass().getSimpleName() + " and " + v.getClass().getSimpleName());
             }
             log.info("Registered LiteraryOutputValidator: {} for {}", v.getClass().getSimpleName(), v.getLiteraryType());
+        }
+        Set<LiteraryType> missing = EnumSet.allOf(LiteraryType.class);
+        missing.removeAll(map.keySet());
+        if (!missing.isEmpty()) {
+            throw new IllegalStateException(
+                    "No LiteraryOutputValidator registered for types: " + missing);
         }
         this.validatorMap = Collections.unmodifiableMap(map);
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/LiteraryValidatorRegistry.java
@@ -24,7 +24,7 @@ public class LiteraryValidatorRegistry {
     public LiteraryOutputValidator getValidator(LiteraryType literaryType) {
         LiteraryOutputValidator v = validatorMap.get(literaryType);
         if (v == null) {
-            return validatorMap.get(LiteraryType.POEM);
+            throw new IllegalArgumentException("No LiteraryOutputValidator registered for type: " + literaryType);
         }
         return v;
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/AbstractLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/AbstractLiteraryOutputValidator.java
@@ -1,0 +1,28 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
+
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractLiteraryOutputValidator implements LiteraryOutputValidator {
+
+    protected abstract int getMinContentLength();
+
+    protected abstract String getTypeName();
+
+    @Override
+    public LiteraryValidationResult validate(String rawContent) {
+        List<String> errors = new ArrayList<>();
+        if (rawContent == null || rawContent.isBlank()) {
+            errors.add("Content is empty");
+            return LiteraryValidationResult.failure(errors);
+        }
+        String t = rawContent.trim();
+        if (t.length() < getMinContentLength()) {
+            errors.add("Content too short (min " + getMinContentLength() + " chars for " + getTypeName() + ")");
+        }
+        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/AbstractLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/AbstractLiteraryOutputValidator.java
@@ -17,13 +17,13 @@ public abstract class AbstractLiteraryOutputValidator implements LiteraryOutputV
     protected abstract String getTypeName();
 
     @Override
-    public LiteraryValidationResult validate(String rawContent) {
+    public final LiteraryValidationResult validate(String rawContent) {
         List<String> errors = new ArrayList<>();
         if (rawContent == null || rawContent.isBlank()) {
             errors.add("Content is empty");
             return LiteraryValidationResult.failure(errors);
         }
-        String trimmed = rawContent.trim();
+        String trimmed = rawContent.strip();
         int minLength = getMinContentLength();
         if (trimmed.length() < minLength) {
             errors.add("Content too short (min " + minLength + " chars for " + getTypeName() + ")");

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/AbstractLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/AbstractLiteraryOutputValidator.java
@@ -1,5 +1,6 @@
 package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
 
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
 import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
 import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
 
@@ -7,6 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractLiteraryOutputValidator implements LiteraryOutputValidator {
+
+    @Override
+    public abstract LiteraryType getLiteraryType();
 
     protected abstract int getMinContentLength();
 
@@ -19,9 +23,10 @@ public abstract class AbstractLiteraryOutputValidator implements LiteraryOutputV
             errors.add("Content is empty");
             return LiteraryValidationResult.failure(errors);
         }
-        String t = rawContent.trim();
-        if (t.length() < getMinContentLength()) {
-            errors.add("Content too short (min " + getMinContentLength() + " chars for " + getTypeName() + ")");
+        String trimmed = rawContent.trim();
+        int minLength = getMinContentLength();
+        if (trimmed.length() < minLength) {
+            errors.add("Content too short (min " + minLength + " chars for " + getTypeName() + ")");
         }
         return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/DefaultLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/DefaultLiteraryOutputValidator.java
@@ -1,0 +1,34 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
+
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class DefaultLiteraryOutputValidator implements LiteraryOutputValidator {
+
+    private static final int MIN_CONTENT_LENGTH = 50;
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.POEM;
+    }
+
+    @Override
+    public LiteraryValidationResult validate(String rawContent) {
+        List<String> errors = new ArrayList<>();
+        if (rawContent == null || rawContent.isBlank()) {
+            errors.add("Content is empty");
+            return LiteraryValidationResult.failure(errors);
+        }
+        String t = rawContent.trim();
+        if (t.length() < MIN_CONTENT_LENGTH) {
+            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars)");
+        }
+        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/DefaultLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/DefaultLiteraryOutputValidator.java
@@ -1,15 +1,10 @@
 package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
 
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class DefaultLiteraryOutputValidator implements LiteraryOutputValidator {
+public class DefaultLiteraryOutputValidator extends AbstractLiteraryOutputValidator {
 
     private static final int MIN_CONTENT_LENGTH = 50;
 
@@ -19,16 +14,12 @@ public class DefaultLiteraryOutputValidator implements LiteraryOutputValidator {
     }
 
     @Override
-    public LiteraryValidationResult validate(String rawContent) {
-        List<String> errors = new ArrayList<>();
-        if (rawContent == null || rawContent.isBlank()) {
-            errors.add("Content is empty");
-            return LiteraryValidationResult.failure(errors);
-        }
-        String t = rawContent.trim();
-        if (t.length() < MIN_CONTENT_LENGTH) {
-            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars)");
-        }
-        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    protected int getMinContentLength() {
+        return MIN_CONTENT_LENGTH;
+    }
+
+    @Override
+    protected String getTypeName() {
+        return "poem";
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/NovelLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/NovelLiteraryOutputValidator.java
@@ -6,7 +6,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class NovelLiteraryOutputValidator extends AbstractLiteraryOutputValidator {
 
-    private static final int MIN_CONTENT_LENGTH = 200;
+    /** First gate: reject obviously truncated output. Short story uses a lower threshold. */
+    private static final int MIN_CONTENT_LENGTH = 2_000;
 
     @Override
     public LiteraryType getLiteraryType() {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/NovelLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/NovelLiteraryOutputValidator.java
@@ -1,0 +1,34 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
+
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class NovelLiteraryOutputValidator implements LiteraryOutputValidator {
+
+    private static final int MIN_CONTENT_LENGTH = 200;
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.NOVEL;
+    }
+
+    @Override
+    public LiteraryValidationResult validate(String rawContent) {
+        List<String> errors = new ArrayList<>();
+        if (rawContent == null || rawContent.isBlank()) {
+            errors.add("Content is empty");
+            return LiteraryValidationResult.failure(errors);
+        }
+        String t = rawContent.trim();
+        if (t.length() < MIN_CONTENT_LENGTH) {
+            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars for novel)");
+        }
+        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/NovelLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/NovelLiteraryOutputValidator.java
@@ -1,15 +1,10 @@
 package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
 
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class NovelLiteraryOutputValidator implements LiteraryOutputValidator {
+public class NovelLiteraryOutputValidator extends AbstractLiteraryOutputValidator {
 
     private static final int MIN_CONTENT_LENGTH = 200;
 
@@ -19,16 +14,12 @@ public class NovelLiteraryOutputValidator implements LiteraryOutputValidator {
     }
 
     @Override
-    public LiteraryValidationResult validate(String rawContent) {
-        List<String> errors = new ArrayList<>();
-        if (rawContent == null || rawContent.isBlank()) {
-            errors.add("Content is empty");
-            return LiteraryValidationResult.failure(errors);
-        }
-        String t = rawContent.trim();
-        if (t.length() < MIN_CONTENT_LENGTH) {
-            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars for novel)");
-        }
-        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    protected int getMinContentLength() {
+        return MIN_CONTENT_LENGTH;
+    }
+
+    @Override
+    protected String getTypeName() {
+        return "novel";
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/PoemLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/PoemLiteraryOutputValidator.java
@@ -4,9 +4,10 @@ import org.example.sharedprompts.module.domain.production.model.literary.Literar
 import org.springframework.stereotype.Component;
 
 @Component
-public class DefaultLiteraryOutputValidator extends AbstractLiteraryOutputValidator {
+public class PoemLiteraryOutputValidator extends AbstractLiteraryOutputValidator {
 
-    private static final int MIN_CONTENT_LENGTH = 50;
+    /** Allows short forms (e.g. haiku, 2-line verse). Raise if product requires longer poems only. */
+    private static final int MIN_CONTENT_LENGTH = 20;
 
     @Override
     public LiteraryType getLiteraryType() {

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ScriptLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ScriptLiteraryOutputValidator.java
@@ -1,0 +1,34 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
+
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ScriptLiteraryOutputValidator implements LiteraryOutputValidator {
+
+    private static final int MIN_CONTENT_LENGTH = 50;
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.SCRIPT;
+    }
+
+    @Override
+    public LiteraryValidationResult validate(String rawContent) {
+        List<String> errors = new ArrayList<>();
+        if (rawContent == null || rawContent.isBlank()) {
+            errors.add("Content is empty");
+            return LiteraryValidationResult.failure(errors);
+        }
+        String t = rawContent.trim();
+        if (t.length() < MIN_CONTENT_LENGTH) {
+            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars for script)");
+        }
+        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ScriptLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ScriptLiteraryOutputValidator.java
@@ -1,15 +1,10 @@
 package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
 
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class ScriptLiteraryOutputValidator implements LiteraryOutputValidator {
+public class ScriptLiteraryOutputValidator extends AbstractLiteraryOutputValidator {
 
     private static final int MIN_CONTENT_LENGTH = 50;
 
@@ -19,16 +14,12 @@ public class ScriptLiteraryOutputValidator implements LiteraryOutputValidator {
     }
 
     @Override
-    public LiteraryValidationResult validate(String rawContent) {
-        List<String> errors = new ArrayList<>();
-        if (rawContent == null || rawContent.isBlank()) {
-            errors.add("Content is empty");
-            return LiteraryValidationResult.failure(errors);
-        }
-        String t = rawContent.trim();
-        if (t.length() < MIN_CONTENT_LENGTH) {
-            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars for script)");
-        }
-        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    protected int getMinContentLength() {
+        return MIN_CONTENT_LENGTH;
+    }
+
+    @Override
+    protected String getTypeName() {
+        return "script";
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ShortStoryLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ShortStoryLiteraryOutputValidator.java
@@ -1,0 +1,34 @@
+package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
+
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
+import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ShortStoryLiteraryOutputValidator implements LiteraryOutputValidator {
+
+    private static final int MIN_CONTENT_LENGTH = 100;
+
+    @Override
+    public LiteraryType getLiteraryType() {
+        return LiteraryType.SHORT_STORY;
+    }
+
+    @Override
+    public LiteraryValidationResult validate(String rawContent) {
+        List<String> errors = new ArrayList<>();
+        if (rawContent == null || rawContent.isBlank()) {
+            errors.add("Content is empty");
+            return LiteraryValidationResult.failure(errors);
+        }
+        String t = rawContent.trim();
+        if (t.length() < MIN_CONTENT_LENGTH) {
+            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars for short story)");
+        }
+        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ShortStoryLiteraryOutputValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/literary/validation/impl/ShortStoryLiteraryOutputValidator.java
@@ -1,15 +1,10 @@
 package org.example.sharedprompts.module.domain.production.service.literary.validation.impl;
 
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryOutputValidator;
-import org.example.sharedprompts.module.domain.production.service.literary.validation.LiteraryValidationResult;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class ShortStoryLiteraryOutputValidator implements LiteraryOutputValidator {
+public class ShortStoryLiteraryOutputValidator extends AbstractLiteraryOutputValidator {
 
     private static final int MIN_CONTENT_LENGTH = 100;
 
@@ -19,16 +14,12 @@ public class ShortStoryLiteraryOutputValidator implements LiteraryOutputValidato
     }
 
     @Override
-    public LiteraryValidationResult validate(String rawContent) {
-        List<String> errors = new ArrayList<>();
-        if (rawContent == null || rawContent.isBlank()) {
-            errors.add("Content is empty");
-            return LiteraryValidationResult.failure(errors);
-        }
-        String t = rawContent.trim();
-        if (t.length() < MIN_CONTENT_LENGTH) {
-            errors.add("Content too short (min " + MIN_CONTENT_LENGTH + " chars for short story)");
-        }
-        return errors.isEmpty() ? LiteraryValidationResult.ok() : LiteraryValidationResult.failure(errors);
+    protected int getMinContentLength() {
+        return MIN_CONTENT_LENGTH;
+    }
+
+    @Override
+    protected String getTypeName() {
+        return "short story";
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
@@ -47,6 +47,7 @@ public class ProductionArtifactService {
 
     /**
      * LITERARY 완성 작품: original.txt, preview.html, final.pdf 3개 파일에 대한 아티팩트 생성.
+     * 검증은 트랜잭션 진입 전에 수행한다.
      */
     public ProductionArtifactEntity createArtifactForLiterary(
             JobEntity job,
@@ -54,6 +55,7 @@ public class ProductionArtifactService {
             String previewHtmlKey,
             String finalPdfKey
     ) {
+        ProductionArtifactTxService.validateLiteraryKeys(originalTxtKey, previewHtmlKey, finalPdfKey);
         return artifactTxService.createInNewTransactionForLiterary(
                 job, originalTxtKey, previewHtmlKey, finalPdfKey);
     }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactService.java
@@ -45,6 +45,19 @@ public class ProductionArtifactService {
         return artifactTxService.createInNewTransaction(job, s3Key, handler, detailData, commandType);
     }
 
+    /**
+     * LITERARY 완성 작품: original.txt, preview.html, final.pdf 3개 파일에 대한 아티팩트 생성.
+     */
+    public ProductionArtifactEntity createArtifactForLiterary(
+            JobEntity job,
+            String originalTxtKey,
+            String previewHtmlKey,
+            String finalPdfKey
+    ) {
+        return artifactTxService.createInNewTransactionForLiterary(
+                job, originalTxtKey, previewHtmlKey, finalPdfKey);
+    }
+
     private ProductionCommandType parseCommandType(JobEntity job) {
         try {
             return ProductionCommandType.valueOf(job.getCommandType());

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
@@ -122,16 +122,9 @@ public class ProductionArtifactTxService {
     }
 
     /**
-     * LITERARY 완성 작품용: original.txt, preview.html, final.pdf 3개 디테일로 아티팩트 생성.
-     * PDF를 primary로 설정한다.
+     * LITERARY 키 검증. 트랜잭션 진입 전에 호출하여 불필요한 커넥션 획득을 피한다.
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 30)
-    public ProductionArtifactEntity createInNewTransactionForLiterary(
-            JobEntity job,
-            String originalTxtKey,
-            String previewHtmlKey,
-            String finalPdfKey
-    ) {
+    public static void validateLiteraryKeys(String originalTxtKey, String previewHtmlKey, String finalPdfKey) {
         if (originalTxtKey == null || originalTxtKey.isBlank()) {
             throw new IllegalArgumentException("originalTxtKey must not be blank");
         }
@@ -141,6 +134,20 @@ public class ProductionArtifactTxService {
         if (finalPdfKey == null || finalPdfKey.isBlank()) {
             throw new IllegalArgumentException("finalPdfKey must not be blank");
         }
+    }
+
+    /**
+     * LITERARY 완성 작품용: original.txt, preview.html, final.pdf 3개 디테일로 아티팩트 생성.
+     * PDF를 primary로 설정한다.
+     * 호출 전에 {@link #validateLiteraryKeys}를 호출할 것.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 30)
+    public ProductionArtifactEntity createInNewTransactionForLiterary(
+            JobEntity job,
+            String originalTxtKey,
+            String previewHtmlKey,
+            String finalPdfKey
+    ) {
         String tenantId = TenantContextValidator.requireTenantContext(
                 "creating literary artifact - jobId: " + job.getJobId());
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
@@ -132,6 +132,15 @@ public class ProductionArtifactTxService {
             String previewHtmlKey,
             String finalPdfKey
     ) {
+        if (originalTxtKey == null || originalTxtKey.isBlank()) {
+            throw new IllegalArgumentException("originalTxtKey must not be blank");
+        }
+        if (previewHtmlKey == null || previewHtmlKey.isBlank()) {
+            throw new IllegalArgumentException("previewHtmlKey must not be blank");
+        }
+        if (finalPdfKey == null || finalPdfKey.isBlank()) {
+            throw new IllegalArgumentException("finalPdfKey must not be blank");
+        }
         String tenantId = TenantContextValidator.requireTenantContext(
                 "creating literary artifact - jobId: " + job.getJobId());
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
@@ -3,10 +3,12 @@ package org.example.sharedprompts.module.domain.production.service.production;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.entity.job.JobEntity;
+import org.example.sharedprompts.module.domain.production.entity.factory.ProductionArtifactDetailEntityFactory;
 import org.example.sharedprompts.module.domain.production.entity.factory.ProductionArtifactEntityFactory;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactDetailEntity;
 import org.example.sharedprompts.module.domain.production.entity.production.ProductionArtifactEntity;
 import org.example.sharedprompts.module.domain.production.model.contract.result.ArtifactType;
+import org.example.sharedprompts.module.domain.production.util.ArtifactMetadataHelper;
 import org.example.sharedprompts.module.domain.production.repository.production.ProductionArtifactRepository;
 import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandler;
 import org.example.sharedprompts.module.domain.production.service.artifact.ArtifactHandlerRegistry;
@@ -117,5 +119,45 @@ public class ProductionArtifactTxService {
         }
 
         return saved;
+    }
+
+    /**
+     * LITERARY 완성 작품용: original.txt, preview.html, final.pdf 3개 디테일로 아티팩트 생성.
+     * PDF를 primary로 설정한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 30)
+    public ProductionArtifactEntity createInNewTransactionForLiterary(
+            JobEntity job,
+            String originalTxtKey,
+            String previewHtmlKey,
+            String finalPdfKey
+    ) {
+        String tenantId = TenantContextValidator.requireTenantContext(
+                "creating literary artifact - jobId: " + job.getJobId());
+
+        ProductionArtifactEntity artifact = ProductionArtifactEntityFactory.create(
+                job.getId(),
+                tenantId,
+                job.getUserId(),
+                ProductionCommandType.LITERARY
+        );
+
+        ProductionArtifactDetailEntity detailOriginal = createFileDetail(originalTxtKey);
+        ProductionArtifactDetailEntity detailPreview = createFileDetail(previewHtmlKey);
+        ProductionArtifactDetailEntity detailPdf = createFileDetail(finalPdfKey);
+
+        artifact.addArtifact(detailOriginal);
+        artifact.addArtifact(detailPreview);
+        artifact.addArtifact(detailPdf);
+        artifact.markAsPrimary(detailPdf);
+
+        return productionArtifactRepository.save(artifact);
+    }
+
+    private static ProductionArtifactDetailEntity createFileDetail(String s3Key) {
+        String fileName = ArtifactMetadataHelper.extractFileName(s3Key);
+        String contentType = ArtifactMetadataHelper.determineContentType(s3Key);
+        return ProductionArtifactDetailEntityFactory.createFile(
+                ArtifactType.FILE, s3Key, fileName, contentType, null, null);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
@@ -126,13 +126,13 @@ public class ProductionArtifactTxService {
      */
     public static void validateLiteraryKeys(String originalTxtKey, String previewHtmlKey, String finalPdfKey) {
         if (originalTxtKey == null || originalTxtKey.isBlank()) {
-            throw new IllegalArgumentException("originalTxtKey must not be blank");
+            throw new BaseException(ModuleErrorCode.VALIDATION_ERROR, null, "originalTxtKey must not be blank");
         }
         if (previewHtmlKey == null || previewHtmlKey.isBlank()) {
-            throw new IllegalArgumentException("previewHtmlKey must not be blank");
+            throw new BaseException(ModuleErrorCode.VALIDATION_ERROR, null, "previewHtmlKey must not be blank");
         }
         if (finalPdfKey == null || finalPdfKey.isBlank()) {
-            throw new IllegalArgumentException("finalPdfKey must not be blank");
+            throw new BaseException(ModuleErrorCode.VALIDATION_ERROR, null, "finalPdfKey must not be blank");
         }
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/production/ProductionArtifactTxService.java
@@ -163,6 +163,10 @@ public class ProductionArtifactTxService {
         return productionArtifactRepository.save(artifact);
     }
 
+    /**
+     * Creates a file detail from an S3 key. fileSize is left null; consider populating from
+     * storage (e.g. getContentLength) when size-based validation or display is needed.
+     */
     private static ProductionArtifactDetailEntity createFileDetail(String s3Key) {
         String fileName = ArtifactMetadataHelper.extractFileName(s3Key);
         String contentType = ArtifactMetadataHelper.determineContentType(s3Key);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/PromptTemplateService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/PromptTemplateService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.domain.prompt.service.PromptService;
 import org.example.sharedprompts.dto.prompt.response.PromptResponseDto;
-import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
+import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommand;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.example.sharedprompts.module.domain.production.service.prompt.literary.LiteraryPromptComposer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,23 +18,28 @@ public class PromptTemplateService {
     private final PromptService promptService;
     private final PromptMerger promptMerger;
     private final PromptValidator promptValidator;
+    private final LiteraryPromptComposer literaryPromptComposer;
 
     @Transactional(readOnly = true)
-    public MergedPrompt mergePrompt(Long promptId, Long userId, ProductionCommandType commandType, String userInput) {
+    public MergedPrompt mergePrompt(Long promptId, Long userId, ProductionCommand command, String userInput) {
+        var commandType = command.getCommandType();
         log.info("Merging prompt - promptId: {}, userId: {}, commandType: {}", promptId, userId, commandType);
 
         PromptResponseDto promptResult = promptService.getPromptDetail(promptId, userId);
         String promptContent = promptResult.getContent();
-        //적용하지 않을 예정
         String promptVersion = "default";
 
-        String mergedContent = promptMerger.merge(promptContent, userInput, commandType);
+        String mergedContent;
+        if (command instanceof LiteraryCommand literaryCommand) {
+            mergedContent = literaryPromptComposer.compose(promptContent, userInput, literaryCommand.literaryType());
+        } else {
+            mergedContent = promptMerger.merge(promptContent, userInput, commandType);
+        }
 
         promptValidator.validateVariables(mergedContent, commandType);
         promptValidator.validateLength(mergedContent);
 
         log.info("Prompt merged successfully - promptId: {}, version: {}, length: {}", promptId, promptVersion, mergedContent.length());
-
         return new MergedPrompt(mergedContent, promptVersion);
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryFormatRules.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryFormatRules.java
@@ -1,0 +1,60 @@
+package org.example.sharedprompts.module.domain.production.service.prompt.literary;
+
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LiteraryFormatRules {
+
+    private static final String OUTPUT_ONLY_RULE = """
+        [필수] 결과물만 출력하세요. 서론, 설명, 주석, 해석, "다음과 같이 작성했습니다" 등의 문구는 절대 포함하지 마세요.
+        """;
+
+    public String getFormatRules(LiteraryType literaryType) {
+        String typeRules = switch (literaryType) {
+            case POEM -> getPoemRules();
+            case SHORT_STORY -> getShortStoryRules();
+            case NOVEL -> getNovelRules();
+            case SCRIPT -> getScriptRules();
+        };
+        return typeRules + "\n" + OUTPUT_ONLY_RULE;
+    }
+
+    private String getPoemRules() {
+        return """
+            [POEM 형식]
+            - 시는 반드시 행(줄) 단위로 구성한다.
+            - 각 행은 한 줄에 한 단위만 출력한다.
+            - 불필요한 산문, 설명, 제목 설명은 포함하지 않는다.
+            - 시 제목만 첫 줄에 두고, 이어서 본문만 출력한다.
+            """;
+    }
+
+    private String getShortStoryRules() {
+        return """
+            [SHORT_STORY 형식]
+            - 단편소설은 도입 → 전개 → 클라이맥스 → 결말 구조를 반드시 따른다.
+            - 완결된 하나의 이야기로 끝낸다.
+            - 중간에 끊기거나 "이어서 쓰려면" 등의 문구를 넣지 않는다.
+            """;
+    }
+
+    private String getNovelRules() {
+        return """
+            [NOVEL 형식]
+            - 장(Chapter) 단위로 구분한다. 각 장에는 "제N장" 또는 "Chapter N" 형태의 제목을 둔다.
+            - 한 번에 요청한 분량만 생성하고, 끝맺음을 명확히 한다.
+            - 장이 여러 개일 경우 이어지는 맥락을 유지한다.
+            """;
+    }
+
+    private String getScriptRules() {
+        return """
+            [SCRIPT 형식]
+            - 소설처럼 서술하는 문체를 사용하지 않는다.
+            - 반드시 "등장인물 이름: 대사" 형식으로만 대사를 쓴다.
+            - 장면 구분은 "Scene N" 또는 "[장면 N]" 등으로 명시한다.
+            - 지문은 최소한으로, (괄호) 안에만 간단히 표기한다.
+            """;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryFormatRules.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryFormatRules.java
@@ -1,16 +1,17 @@
 package org.example.sharedprompts.module.domain.production.service.prompt.literary;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
-import org.springframework.stereotype.Component;
 
-@Component
-public class LiteraryFormatRules {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LiteraryFormatRules {
 
     private static final String OUTPUT_ONLY_RULE = """
         [필수] 결과물만 출력하세요. 서론, 설명, 주석, 해석, "다음과 같이 작성했습니다" 등의 문구는 절대 포함하지 마세요.
         """;
 
-    public String getFormatRules(LiteraryType literaryType) {
+    public static String getFormatRules(LiteraryType literaryType) {
         String typeRules = switch (literaryType) {
             case POEM -> getPoemRules();
             case SHORT_STORY -> getShortStoryRules();
@@ -20,7 +21,7 @@ public class LiteraryFormatRules {
         return typeRules + "\n" + OUTPUT_ONLY_RULE;
     }
 
-    private String getPoemRules() {
+    private static String getPoemRules() {
         return """
             [POEM 형식]
             - 시는 반드시 행(줄) 단위로 구성한다.
@@ -30,7 +31,7 @@ public class LiteraryFormatRules {
             """;
     }
 
-    private String getShortStoryRules() {
+    private static String getShortStoryRules() {
         return """
             [SHORT_STORY 형식]
             - 단편소설은 도입 → 전개 → 클라이맥스 → 결말 구조를 반드시 따른다.
@@ -39,7 +40,7 @@ public class LiteraryFormatRules {
             """;
     }
 
-    private String getNovelRules() {
+    private static String getNovelRules() {
         return """
             [NOVEL 형식]
             - 장(Chapter) 단위로 구분한다. 각 장에는 "제N장" 또는 "Chapter N" 형태의 제목을 둔다.
@@ -48,7 +49,7 @@ public class LiteraryFormatRules {
             """;
     }
 
-    private String getScriptRules() {
+    private static String getScriptRules() {
         return """
             [SCRIPT 형식]
             - 소설처럼 서술하는 문체를 사용하지 않는다.

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryPromptComposer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryPromptComposer.java
@@ -1,0 +1,32 @@
+package org.example.sharedprompts.module.domain.production.service.prompt.literary;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LiteraryPromptComposer {
+
+    private final LiteraryFormatRules formatRules;
+
+    public String compose(String promptContent, String userInput, LiteraryType literaryType) {
+        String formatRulesText = formatRules.getFormatRules(literaryType);
+        String withUserInput = mergeUserInput(promptContent, userInput);
+        String composed = withUserInput + "\n\n---\n\n" + formatRulesText;
+        log.debug("Literary prompt composed - literaryType: {}, length: {}", literaryType, composed.length());
+        return composed;
+    }
+
+    private String mergeUserInput(String promptContent, String userInput) {
+        if (userInput == null || userInput.isBlank()) {
+            return promptContent;
+        }
+        if (promptContent != null && promptContent.contains("{{userInput}}")) {
+            return promptContent.replace("{{userInput}}", userInput);
+        }
+        return (promptContent != null ? promptContent : "") + "\n\n사용자 요청: " + userInput;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryPromptComposer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryPromptComposer.java
@@ -5,12 +5,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class LiteraryPromptComposer {
 
     public String compose(String promptContent, String userInput, LiteraryType literaryType) {
+        Objects.requireNonNull(literaryType, "literaryType must not be null");
         String formatRulesText = LiteraryFormatRules.getFormatRules(literaryType);
         String withUserInput = mergeUserInput(promptContent, userInput);
         String composed = withUserInput + "\n\n---\n\n" + formatRulesText;
@@ -20,7 +23,7 @@ public class LiteraryPromptComposer {
 
     private String mergeUserInput(String promptContent, String userInput) {
         if (userInput == null || userInput.isBlank()) {
-            return promptContent;
+            return promptContent != null ? promptContent : "";
         }
         if (promptContent != null && promptContent.contains("{{userInput}}")) {
             return promptContent.replace("{{userInput}}", userInput);

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryPromptComposer.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/service/prompt/literary/LiteraryPromptComposer.java
@@ -10,10 +10,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class LiteraryPromptComposer {
 
-    private final LiteraryFormatRules formatRules;
-
     public String compose(String promptContent, String userInput, LiteraryType literaryType) {
-        String formatRulesText = formatRules.getFormatRules(literaryType);
+        String formatRulesText = LiteraryFormatRules.getFormatRules(literaryType);
         String withUserInput = mergeUserInput(promptContent, userInput);
         String composed = withUserInput + "\n\n---\n\n" + formatRulesText;
         log.debug("Literary prompt composed - literaryType: {}, length: {}", literaryType, composed.length());

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/util/ArtifactMetadataHelper.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/util/ArtifactMetadataHelper.java
@@ -33,6 +33,7 @@ public final class ArtifactMetadataHelper {
         return switch (commandType) {
             case TEXT, EMAIL, BLOG, DOCUMENT -> ArtifactType.TEXT;
             case IMAGE -> ArtifactType.IMAGE;
+            case LITERARY -> ArtifactType.FILE;
         };
     }
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/validation/LiteraryCommandValidator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/production/validation/LiteraryCommandValidator.java
@@ -1,0 +1,29 @@
+package org.example.sharedprompts.module.domain.production.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommand;
+import org.example.sharedprompts.module.domain.production.model.contract.command.ProductionCommandType;
+import org.example.sharedprompts.module.domain.production.model.executor.literary.LiteraryCommand;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class LiteraryCommandValidator implements ProductionValidator {
+
+    @Override
+    public void validate(ProductionCommand command) throws ValidationException {
+        if (!(command instanceof LiteraryCommand literaryCommand)) {
+            throw new ValidationException(
+                    "Command is not instance of LiteraryCommand: " + command.getClass().getName());
+        }
+        if (literaryCommand.literaryType() == null) {
+            throw new ValidationException("literaryType must not be null");
+        }
+        log.debug("LiteraryCommand validation passed - literaryType: {}", literaryCommand.literaryType());
+    }
+
+    @Override
+    public boolean supports(ProductionCommandType commandType) {
+        return commandType == ProductionCommandType.LITERARY;
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/production/LiteraryProductionRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/production/LiteraryProductionRequestDto.java
@@ -1,12 +1,14 @@
 package org.example.sharedprompts.module.dto.request.production;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryFormat;
 import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
 
 public record LiteraryProductionRequestDto(
         @NotNull LiteraryType literaryType,
         @NotBlank String fileName,
-        @NotBlank String format,
-        String userInput
+        @NotNull LiteraryFormat format,
+        @Nullable String userInput
 ) implements ProductionRequest {}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/production/LiteraryProductionRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/production/LiteraryProductionRequestDto.java
@@ -1,0 +1,12 @@
+package org.example.sharedprompts.module.dto.request.production;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.sharedprompts.module.domain.production.model.literary.LiteraryType;
+
+public record LiteraryProductionRequestDto(
+        @NotNull LiteraryType literaryType,
+        @NotBlank String fileName,
+        @NotBlank String format,
+        String userInput
+) implements ProductionRequest {}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/production/TextProductionRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/production/TextProductionRequestDto.java
@@ -1,10 +1,6 @@
 package org.example.sharedprompts.module.dto.request.production;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record TextProductionRequestDto(
-    @NotBlank String fileName,
-    @NotBlank String format,
     String userInput
 ) implements ProductionRequest {}
 


### PR DESCRIPTION
…SCRIPT)

- Add LiteraryType, LiteraryCommand, LITERARY command type
- Prompt composition: LiteraryPromptComposer + LiteraryFormatRules per type
- Strategy pattern: PoemGenerationStrategy, ShortStoryGenerationStrategy, NovelGenerationStrategy, ScriptGenerationStrategy
- Output pipeline: Markdown sanitize -> original.txt, preview.html, final.pdf -> S3 upload (production/{userId}/{jobId}/), artifact with 3 details
- Literary output validation + retry; Novel token estimation structure
- DTO: TextProductionRequestDto drops fileName/format (defaults in factory); LiteraryProductionRequestDto adds @NotBlank fileName, format
- POST /prompts/{id}/production/literary endpoint
- Code cleanup: minimal comments, explicit imports, no wildcards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 문학 작품 생성 기능 추가: 시, 단편, 소설, 대본 등 다양한 문학 형식 지원
  * 문학 생성 요청 전용 API 엔드포인트 추가

* **Documentation**
  * 문학 생성 아키텍처 설명서 추가
  * S3 시간 동기화 및 복구 전략 가이드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->