### PR TITLE
feat(github-body): add GitHub body generation module

### DIFF
--- a/sharedPrompts/README.GITHUB_BODY.md
+++ b/sharedPrompts/README.GITHUB_BODY.md
@@ -1,0 +1,112 @@
+# GitHub Body 생성 API (Issue + PR Markdown)
+
+Webhook/API 요청 1번으로 Issue 본문과 PR 본문 Markdown을 **동시에** 생성하고, 같은 `jobId` 아래 S3에 `issue-{jobId}.md`, `pr-{jobId}.md` 로 저장한 뒤, 본문과 저장 키를 함께 반환합니다.  
+**GitHub에 실제 Issue/PR을 생성하지 않습니다.** 본문만 생성·저장·반환합니다.
+
+---
+
+## API
+
+### POST /api/github/bodies/generate
+
+- **request:** `GitHubBodyRequestDto` (JSON)
+- **response:** `{ "success": true, "data": GitHubBodyResponseDto }` (프로젝트 공통 응답 포맷)
+
+---
+
+## 환경 설정
+
+| 목적 | 설정 키 | 기본값 / 비고 |
+|------|----------|----------------|
+| Groq API Key | `ai.provider.groq.secret-key` | (또는 기존 GROQ_API_KEY 매핑) 필수 |
+| Groq Base URL | `ai.provider.groq.base-url` | `https://api.groq.com/openai/v1` |
+| Groq Model | `ai.provider.groq.default-model-id` | **기본:** `llama-3.3-70b-versatile` / **옵션:** `llama-3.1-8b-instant` (비용·속도 절감) |
+| Groq temperature | (클라이언트 확장 시) | 스펙 권장 0.2~0.3. 현재 TextAiClient 미지원 시 기본값 사용 (TODO) |
+| S3 | `production.storage.type=S3` | `production.storage.s3.prefix` 기본 `production` |
+
+---
+
+## jobId 결정 규칙 (resolveJobId)
+
+- **우선순위:** `jobId` → `deliveryId` → `sha`
+- **세 값 모두 없으면:** `400 Bad Request`  
+  메시지: `"jobId, deliveryId, sha 중 하나 이상 필요"`
+- 같은 `jobId` 로 재요청 시 **멱등:** 이미 S3에 `issue-{jobId}.md`, `pr-{jobId}.md` 가 **둘 다 존재**하면 Groq 호출·재생성·재저장 모두 스킵하고, S3에서 두 파일을 읽어 `issueBody`/`prBody` 를 채운 뒤 기존 S3 키와 함께 동일 응답 형태로 반환합니다.
+
+---
+
+## S3 저장 키 규칙 (강제)
+
+- **형식:** `{prefix}/{tenantId}/0/{jobId}/{fileName}`
+  - `prefix`: `production.storage.s3.prefix` (기본 `production`)
+  - `tenantId`: **우선순위** request.tenantId → TenantContext → `"github"`
+  - `0`: 웹훅용 고정 userId
+  - `fileName`: `issue-{jobId}.md`, `pr-{jobId}.md`
+- **예:**
+  - `production/github/0/abc123/issue-abc123.md`
+  - `production/github/0/abc123/pr-abc123.md`
+- **contentType:** `text/markdown`
+
+---
+
+## 입력 크기 제한 (서비스 안정성)
+
+- **commits:** 최대 50줄. 초과 시 앞 50줄만 사용하고 `"... and N more"` 로 축약해 프롬프트에 반영.
+- **files:** 최대 200줄. 초과 시 앞 200줄만 사용하고 `"... and N more"` 로 축약.
+
+---
+
+## 요청 / 응답 예시
+
+### 요청 (JSON)
+
+```json
+{
+  "jobId": "optional-job-id",
+  "deliveryId": "webhook-delivery-id",
+  "sha": "abc123def",
+  "repoFullName": "owner/repo",
+  "branch": "feature/xyz",
+  "baseBranch": "main",
+  "title": "feat: add GitHub body API",
+  "author": "dev",
+  "date": "2025-02-23",
+  "commits": "feat: add endpoint\n\n- POST /github/bodies/generate",
+  "files": "src/.../GitHubBodyController.java\nsrc/.../GitHubBodyGeneratorService.java",
+  "tenantId": "github"
+}
+```
+
+- `jobId`, `deliveryId`, `sha` 중 **하나 이상 필수**.
+- `baseBranch` 없으면 `"main"` 사용.
+- `commits` / `files` 는 줄 단위 문자열 (50줄/200줄 초과 시 자동 축약).
+
+### 응답 (200 OK)
+
+```json
+{
+  "success": true,
+  "data": {
+    "jobId": "optional-job-id",
+    "issueBody": "## TL;DR\n- ...\n\n[AUTO_JOB_ID:optional-job-id]\n[AUTO_PUSH_DELIVERY:...]\n[AUTO_PUSH_SHA:...]",
+    "prBody": "# Summary\n- ...\n\n[AUTO_JOB_ID:optional-job-id]\n...",
+    "storedIssueFileKey": "production/github/0/optional-job-id/issue-optional-job-id.md",
+    "storedPrFileKey": "production/github/0/optional-job-id/pr-optional-job-id.md"
+  }
+}
+```
+
+---
+
+## DELIVERY에서 사용하는 방법
+
+- 응답의 `storedIssueFileKey` / `storedPrFileKey` 로 S3에서 본문을 읽어와서, GitHub API로 Issue 또는 PR 생성 시 `body` 필드에 그대로 넣으면 됩니다.
+- 즉, DELIVERY는 **storedIssueFileKey**·**storedPrFileKey** 를 읽어 각각 Issue 본문 / PR 본문으로 사용합니다.
+
+---
+
+## 원자성 / 보상 (권장 구현)
+
+- 저장 순서: issue → pr.
+- pr 저장 실패 시, 이미 저장된 issue 파일을 **delete(보상 삭제)** 하여 jobId 하위에 한 파일만 남지 않게 합니다.
+- delete 실패 시 경고 로그 후, 최종적으로 실패 응답(500/502) 처리합니다.

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/controller/github/GitHubBodyController.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/controller/github/GitHubBodyController.java
@@ -1,0 +1,38 @@
+package org.example.sharedprompts.module.controller.github;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.dto.common.CustomResponse;
+import org.example.sharedprompts.dto.common.CustomResponseHelper;
+import org.example.sharedprompts.module.domain.github.GitHubBodyGenerateApplicationService;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+import org.example.sharedprompts.module.dto.response.github.GitHubBodyResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * GitHub Issue/PR 본문 생성 API (Markdown만 생성·저장·반환).
+ * 오케스트레이션은 GitHubBodyGenerateApplicationService에 위임.
+ */
+@RestController
+@RequestMapping("prompts/{promptId}/github")
+@RequiredArgsConstructor
+@Slf4j
+public class GitHubBodyController {
+
+    private final GitHubBodyGenerateApplicationService applicationService;
+
+    @PostMapping("/bodies/generate")
+    public ResponseEntity<CustomResponse<GitHubBodyResponseDto>> generate(
+            @PathVariable Long promptId,
+            @Valid @RequestBody GitHubBodyRequestDto request
+    ) {
+        GitHubBodyResponseDto response = applicationService.generate(promptId, request);
+        return CustomResponseHelper.ok(response);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyFileNames.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyFileNames.java
@@ -1,0 +1,18 @@
+package org.example.sharedprompts.module.domain.github;
+
+/**
+ * S3 저장 시 파일명 규칙: 같은 jobId 아래 issue-{jobId}.md, pr-{jobId}.md.
+ * 변경 시 이 클래스만 수정하면 되도록 분리.
+ */
+public final class GitHubBodyFileNames {
+
+    private GitHubBodyFileNames() {}
+
+    public static String issueFileName(String jobId) {
+        return "issue-" + jobId + ".md";
+    }
+
+    public static String prFileName(String jobId) {
+        return "pr-" + jobId + ".md";
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyGenerateApplicationService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyGenerateApplicationService.java
@@ -1,0 +1,45 @@
+package org.example.sharedprompts.module.domain.github;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+import org.example.sharedprompts.module.dto.response.github.GitHubBodyResponseDto;
+import org.springframework.stereotype.Service;
+
+/**
+ * GitHub Issue/PR 본문 생성 오케스트레이션.
+ * 멱등 확인 → 기존 키 있으면 다운로드 반환 / 없으면 생성 → 저장 → 응답 생성.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GitHubBodyGenerateApplicationService {
+
+    private final GitHubBodyGeneratorService generatorService;
+    private final GitHubBodyStorageService storageService;
+
+    public GitHubBodyResponseDto generate(Long promptId, GitHubBodyRequestDto request) {
+        String jobId = request.resolveJobId();
+        log.info("GitHub body generation requested - promptId: {}, jobId: {}, repo: {}", promptId, jobId, request.repoFullName());
+
+        var existing = storageService.tryGetExistingKeys(request);
+        if (existing.isPresent()) {
+            var keys = existing.get();
+            String issueBody = storageService.downloadBody(keys.storedIssueFileKey());
+            String prBody = storageService.downloadBody(keys.storedPrFileKey());
+            return new GitHubBodyResponseDto(
+                    jobId, issueBody, prBody,
+                    keys.storedIssueFileKey(), keys.storedPrFileKey());
+        }
+
+        GitHubBodyGeneratorService.GitHubBodyPair pair = generatorService.generateBoth(promptId, request);
+        GitHubBodyStorageService.StoredKeys keys = storageService.saveBothAsMarkdown(
+                pair.issueBody(), pair.prBody(), request);
+        return new GitHubBodyResponseDto(
+                jobId,
+                pair.issueBody(),
+                pair.prBody(),
+                keys.storedIssueFileKey(),
+                keys.storedPrFileKey());
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyGeneratorService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyGeneratorService.java
@@ -1,0 +1,112 @@
+package org.example.sharedprompts.module.domain.github;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.domain.prompt.service.PromptService;
+import org.example.sharedprompts.module.domain.production.service.ai.text.TextAiClient;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto.Kind;
+import org.example.sharedprompts.module.exception.BaseException;
+import org.example.sharedprompts.module.exception.ModuleErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * GitHub Issue/PR 본문 Markdown 생성.
+ * path의 promptId로 조회한 프롬프트 content를 본문 템플릿으로 사용(Issue·PR 공통). null이면 GitHubBodyTemplates 상수 사용.
+ */
+@Service
+@Slf4j
+public class GitHubBodyGeneratorService {
+
+    private final TextAiClient textAiClient;
+    private final PromptService promptService;
+
+    public GitHubBodyGeneratorService(
+            @Autowired(required = false) @Nullable TextAiClient textAiClient,
+            PromptService promptService) {
+        this.textAiClient = textAiClient;
+        this.promptService = promptService;
+    }
+
+    public GitHubBodyPair generateBoth(Long bodyTemplatePromptId, GitHubBodyRequestDto request) {
+        String issueBody = generateBody(bodyTemplatePromptId, request, Kind.ISSUE);
+        String prBody = generateBody(bodyTemplatePromptId, request, Kind.PR);
+        return new GitHubBodyPair(issueBody, prBody);
+    }
+
+    public String generateBody(Long bodyTemplatePromptId, GitHubBodyRequestDto request, Kind kind) {
+        GitHubBodyVars vars = GitHubBodyVars.from(request);
+        Map<String, String> varMap = vars.toMap();
+        String template = resolveBodyTemplate(bodyTemplatePromptId, kind);
+
+        if (textAiClient != null) {
+            try {
+                String systemPrompt = kind == Kind.PR ? GitHubBodyTemplates.AI_SYSTEM_PR : GitHubBodyTemplates.AI_SYSTEM_ISSUE;
+                String userPrompt = buildUserPrompt(request, kind, template);
+                String combinedPrompt = systemPrompt + "\n\n---\n\n" + userPrompt;
+                // TODO: Groq 호출 시 temperature 0.2~0.3 권장. 현재 TextAiClient가 temperature 미지원 시 기본값 사용.
+                String generated = textAiClient.generateText(combinedPrompt, null, "markdown");
+                if (generated != null && !generated.isBlank()) {
+                    return GitHubBodyPlaceholderSubstitutor.substitute(generated.trim(), varMap);
+                }
+            } catch (Exception e) {
+                log.warn("GitHub body AI generation failed, using template fallback: {}", e.getMessage());
+            }
+        }
+
+        return GitHubBodyPlaceholderSubstitutor.substitute(template, varMap);
+    }
+
+    public record GitHubBodyPair(String issueBody, String prBody) {}
+
+    /** path의 promptId가 있으면 prompts 테이블에서 조회(Issue·PR 공통 템플릿), 없으면 GitHubBodyTemplates 상수. */
+    private String resolveBodyTemplate(Long bodyTemplatePromptId, Kind kind) {
+        if (bodyTemplatePromptId != null) {
+            try {
+                String content = promptService.getPromptDetail(bodyTemplatePromptId, null).getContent();
+                if (content != null && !content.isBlank()) return content;
+            } catch (Exception e) {
+                log.warn("Failed to load body template by promptId {}: {}", bodyTemplatePromptId, e.getMessage());
+                throw new BaseException(ModuleErrorCode.GITHUB_BODY_PROMPT_NOT_FOUND, "prompts/id not found: " + bodyTemplatePromptId, e);
+            }
+        }
+        return kind == Kind.PR ? GitHubBodyTemplates.PR_BODY : GitHubBodyTemplates.ISSUE_BODY;
+    }
+
+    private String buildUserPrompt(GitHubBodyRequestDto request, Kind kind, String outputStructureTemplate) {
+        GitHubBodyVars v = GitHubBodyVars.from(request);
+        return """
+                Generate the GitHub %s body. Use the following output structure (keep {{REPO}}, {{SHA}}, {{BRANCH}}, {{BASE_BRANCH}}, {{JOB_ID}}, {{DELIVERY_ID}} as-is). Fill every other part from the input below.
+
+                OUTPUT STRUCTURE:
+                %s
+
+                ---
+
+                INPUT:
+                Repository: %s
+                Base Branch: %s
+                Branch: %s
+                Commit SHA: %s
+                Title: %s
+                Author: %s
+                Date: %s
+
+                Commits:
+                %s
+
+                Changed Files:
+                %s
+                """
+                .formatted(
+                        kind == Kind.PR ? "Pull Request" : "Issue",
+                        outputStructureTemplate,
+                        v.repo(), v.baseBranch(), v.branch(), v.sha(),
+                        v.title(), v.author(), v.date(),
+                        v.commits(), v.files()
+                );
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyInputTruncator.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyInputTruncator.java
@@ -1,0 +1,36 @@
+package org.example.sharedprompts.module.domain.github;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * 입력 크기 제한: commits 최대 50줄, files 최대 200줄.
+ * 초과 시 앞부분만 사용하고 "... and N more"로 축약하여 프롬프트 안정성 확보.
+ */
+public final class GitHubBodyInputTruncator {
+
+    public static final int MAX_COMMIT_LINES = 50;
+    public static final int MAX_FILE_LINES = 200;
+
+    private GitHubBodyInputTruncator() {}
+
+    /**
+     * 줄 단위로 잘라서 최대 maxLines줄만 사용하고, 초과분이 있으면 "... and N more"를 붙인다.
+     */
+    public static String truncateToLines(String text, int maxLines) {
+        if (text == null || text.isBlank()) return "";
+        String[] lines = text.split("\n", -1);
+        if (lines.length <= maxLines) return text;
+        String head = Arrays.stream(lines).limit(maxLines).collect(Collectors.joining("\n"));
+        int more = lines.length - maxLines;
+        return head + "\n... and " + more + " more";
+    }
+
+    public static String truncateCommits(String commits) {
+        return truncateToLines(commits, MAX_COMMIT_LINES);
+    }
+
+    public static String truncateFiles(String files) {
+        return truncateToLines(files, MAX_FILE_LINES);
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyPlaceholderSubstitutor.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyPlaceholderSubstitutor.java
@@ -1,0 +1,28 @@
+package org.example.sharedprompts.module.domain.github;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * {{PLACEHOLDER}} 형태의 문자열 치환. 템플릿/생성 결과에 공통 적용.
+ */
+public final class GitHubBodyPlaceholderSubstitutor {
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{\\{([A-Z_]+)\\}\\}");
+
+    private GitHubBodyPlaceholderSubstitutor() {}
+
+    public static String substitute(String template, Map<String, String> vars) {
+        if (template == null) return "";
+        Matcher m = PLACEHOLDER.matcher(template);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String key = m.group(1);
+            String value = vars.getOrDefault(key, "");
+            m.appendReplacement(sb, Matcher.quoteReplacement(value));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyStorageService.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyStorageService.java
@@ -1,0 +1,110 @@
+package org.example.sharedprompts.module.domain.github;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.sharedprompts.module.domain.production.application.storage.StorageFacade;
+import org.example.sharedprompts.module.domain.production.infra.storage.S3KeyGenerator;
+import org.example.sharedprompts.module.domain.production.model.tenant.TenantContext;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Saves generated GitHub Issue and PR bodies as .md files (S3) under the same jobId.
+ * Key rule: {prefix}/{tenantId}/0/{jobId}/issue-{jobId}.md, pr-{jobId}.md.
+ * Idempotency: when both files already exist, returns existing keys without overwrite.
+ * On PR save failure after Issue save: deletes Issue (compensation) and rethrows.
+ */
+@Service
+@Slf4j
+public class GitHubBodyStorageService {
+
+    private static final long WEBHOOK_USER_ID = 0L;
+
+    private final StorageFacade storageFacade;
+    private final S3KeyGenerator keyGenerator;
+
+    public GitHubBodyStorageService(
+            @Autowired(required = false) @Nullable StorageFacade storageFacade,
+            @Autowired(required = false) @Nullable S3KeyGenerator keyGenerator) {
+        this.storageFacade = storageFacade;
+        this.keyGenerator = keyGenerator;
+    }
+
+    /**
+     * If both issue-{jobId}.md and pr-{jobId}.md exist, returns their keys (for idempotent skip).
+     */
+    public Optional<StoredKeys> tryGetExistingKeys(GitHubBodyRequestDto request) {
+        if (storageFacade == null || keyGenerator == null) {
+            return Optional.empty();
+        }
+        String jobId = request.resolveJobId();
+        String tenantId = resolveTenantId(request);
+        String issueKey = keyGenerator.generateKey(tenantId, WEBHOOK_USER_ID, jobId, GitHubBodyFileNames.issueFileName(jobId));
+        String prKey = keyGenerator.generateKey(tenantId, WEBHOOK_USER_ID, jobId, GitHubBodyFileNames.prFileName(jobId));
+        if (storageFacade.exists(issueKey) && storageFacade.exists(prKey)) {
+            log.debug("GitHub bodies already exist for jobId: {}, returning existing keys", jobId);
+            return Optional.of(new StoredKeys(issueKey, prKey));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Saves both under the same jobId. Same key rule as above.
+     * If PR save fails after Issue save, deletes the Issue object and rethrows.
+     */
+    public StoredKeys saveBothAsMarkdown(String issueBody, String prBody, GitHubBodyRequestDto request) {
+        if (storageFacade == null) {
+            log.debug("StorageFacade not available, skipping save");
+            return new StoredKeys(null, null);
+        }
+        String jobId = request.resolveJobId();
+        String tenantId = resolveTenantId(request);
+        String issueFileName = GitHubBodyFileNames.issueFileName(jobId);
+        String prFileName = GitHubBodyFileNames.prFileName(jobId);
+
+        String issueKey = null;
+        try {
+            issueKey = uploadOne(issueBody, tenantId, jobId, issueFileName);
+            String prKey = uploadOne(prBody, tenantId, jobId, prFileName);
+            if (issueKey != null || prKey != null) {
+                log.info("GitHub bodies saved for jobId: {} - issue: {}, pr: {}", jobId, issueKey != null, prKey != null);
+            }
+            return new StoredKeys(issueKey, prKey);
+        } catch (Exception e) {
+            if (issueKey != null) {
+                try {
+                    storageFacade.delete(issueKey);
+                    log.warn("Compensation: deleted issue file after PR save failure - key: {}", issueKey);
+                } catch (Exception deleteEx) {
+                    log.error("Compensation delete failed for key {}: {}", issueKey, deleteEx.getMessage());
+                }
+            }
+            throw e;
+        }
+    }
+
+    /** Download body by S3 key (UTF-8). For idempotent response when both keys already exist. */
+    public String downloadBody(String s3Key) {
+        if (storageFacade == null || s3Key == null) return "";
+        byte[] bytes = storageFacade.download(s3Key);
+        return bytes != null ? new String(bytes, StandardCharsets.UTF_8) : "";
+    }
+
+    private String resolveTenantId(GitHubBodyRequestDto request) {
+        if (request.tenantId() != null && !request.tenantId().isBlank()) return request.tenantId();
+        String fromContext = TenantContext.getCurrentTenantId();
+        return (fromContext != null && !fromContext.isBlank()) ? fromContext : "github";
+    }
+
+    @Nullable
+    private String uploadOne(String body, String tenantId, String jobId, String fileName) {
+        if (body == null || body.isBlank()) return null;
+        return storageFacade.upload(body, tenantId, WEBHOOK_USER_ID, jobId, fileName);
+    }
+
+    public record StoredKeys(String storedIssueFileKey, String storedPrFileKey) {}
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyTemplates.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyTemplates.java
@@ -1,0 +1,118 @@
+package org.example.sharedprompts.module.domain.github;
+
+/**
+ * Issue/PR 본문 템플릿 및 AI 시스템 프롬프트 상수.
+ * 변경 시 이 클래스만 수정하면 되도록 분리.
+ */
+public final class GitHubBodyTemplates {
+
+    private GitHubBodyTemplates() {}
+
+    public static final String ISSUE_BODY = """
+            ## TL;DR
+            - TODO: Summarize technical intent from commit messages.
+            - TODO: Summarize impact (scope, affected areas).
+            - TODO: Follow-up or dependency if any.
+
+            ## Background / Context
+            Changes in this push (branch **{{BRANCH}}**) are described by the commit messages below.
+
+            ```
+            {{COMMITS}}
+            ```
+
+            If the above is empty or unclear, add a short explanation of what changed and why.
+
+            ## Requirements
+            - [ ] TODO: Derive from commit intent (e.g. behaviour implemented, validation added).
+            - [ ] TODO: Add further items based on commits and changed files.
+
+            ## Acceptance Criteria
+            - [ ] TODO: Define measurable success (e.g. tests pass, no new linter errors).
+            - [ ] TODO: Add criteria matching scope of changed files and commit intent.
+
+            ## Risks & Notes
+            TODO: Risk analysis needed. After reviewing commits and files, consider: breaking changes, DB/schema impact, API contract, performance, concurrency, deployment risk.
+
+            ## Test Plan
+            - **Unit tests:** TODO: Suggest tests for new or changed logic.
+            - **Integration tests:** TODO: Suggest API or DB integration tests if applicable.
+            - **Manual verification:** TODO: Steps to validate in dev/staging.
+
+            ## Links
+            - Commit: https://github.com/{{REPO}}/commit/{{SHA}}
+
+            ---
+            [AUTO_JOB_ID:{{JOB_ID}}]
+            [AUTO_PUSH_DELIVERY:{{DELIVERY_ID}}]
+            [AUTO_PUSH_SHA:{{SHA}}]
+            """;
+
+    public static final String PR_BODY = """
+            # Summary
+            - TODO: Summarize main scope from commit messages.
+            - TODO: State primary intent (e.g. feature, fix, refactor).
+            - TODO: Note any notable side effects or follow-ups.
+
+            # What Changed
+            ## Key Modifications
+            - TODO: Group changes by area (e.g. API, domain, persistence) using commits and files.
+            - TODO: Call out structural or architectural impact if any.
+
+            ## Files Impacted
+            - TODO: Classify touched files (controller / service / domain / config / tests). If unclear, omit or list paths only.
+
+            # Why
+            TODO: Clarify motivation from commit messages. If not inferable, leave as "TODO: clarify motivation".
+
+            # Risk Analysis
+            - **Breaking changes:** TODO: Yes/No + brief note.
+            - **Backward compatibility:** TODO: Assess (API, config, behaviour).
+            - **DB or data impact:** TODO: None / migration / data change.
+            - **Performance impact:** TODO: None / localized / broader.
+            - **Concurrency issues:** TODO: None / possible / confirmed.
+            - **Deployment risk:** TODO: Low / Medium / High and why.
+
+            **Risk level:** TODO: LOW / MEDIUM / HIGH
+            **Reasoning:** TODO: One or two sentences.
+
+            # How to Test
+            - **Unit tests:** TODO: What to run or add.
+            - **Integration tests:** TODO: Scenarios or suites to run.
+            - **Manual verification:** TODO: Steps (e.g. call endpoint, check DB/UI).
+
+            # Rollback Plan
+            TODO: Define rollback strategy (e.g. revert commit, feature flag off, DB rollback). If unclear: "TODO: define rollback strategy".
+
+            # Checklist
+            - [ ] Code reviewed
+            - [ ] Tests updated
+            - [ ] Backward compatibility checked
+            - [ ] Rollback considered
+
+            # Related Links
+            - Compare: https://github.com/{{REPO}}/compare/{{BASE_BRANCH}}...{{BRANCH}}
+            - Commit: https://github.com/{{REPO}}/commit/{{SHA}}
+
+            ---
+            [AUTO_JOB_ID:{{JOB_ID}}]
+            [AUTO_PUSH_DELIVERY:{{DELIVERY_ID}}]
+            [AUTO_PUSH_SHA:{{SHA}}]
+            """;
+
+    public static final String AI_SYSTEM_ISSUE = """
+            You are a senior software engineer writing a professional GitHub Issue body in Markdown.
+            RULES: Output Markdown only. Use ONLY the provided commit and file information; do not hallucinate.
+            If something is unclear, write "TODO:" instead of guessing. Keep the exact section structure.
+            In the output, keep the placeholders {{REPO}}, {{SHA}}, {{BRANCH}}, {{JOB_ID}}, {{DELIVERY_ID}} exactly as written (they will be replaced by the system).
+            Fill all other sections (TL;DR, Background, Requirements, Acceptance Criteria, Risks, Test Plan) from the commits and changed files.
+            """;
+
+    public static final String AI_SYSTEM_PR = """
+            You are a senior backend engineer writing a professional GitHub Pull Request body in Markdown.
+            RULES: Output Markdown only. Use ONLY the provided commit and file information; do not hallucinate.
+            If something is unclear, write "TODO:". Keep the exact section structure.
+            In the output, keep the placeholders {{REPO}}, {{SHA}}, {{BRANCH}}, {{BASE_BRANCH}}, {{JOB_ID}}, {{DELIVERY_ID}} exactly as written (they will be replaced by the system).
+            Fill all sections (Summary, What Changed, Why, Risk Analysis, How to Test, Rollback Plan) from the commits and changed files.
+            """;
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyVars.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/domain/github/GitHubBodyVars.java
@@ -1,0 +1,67 @@
+package org.example.sharedprompts.module.domain.github;
+
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * 템플릿 치환용 변수 집합. Request에서 한 곳에서만 생성하여 일관성 유지.
+ */
+public record GitHubBodyVars(
+        String repo,
+        String baseBranch,
+        String branch,
+        String sha,
+        String title,
+        String author,
+        String date,
+        String commits,
+        String files,
+        String jobId,
+        String deliveryId
+) {
+
+    public static GitHubBodyVars from(GitHubBodyRequestDto request) {
+        String jobId = request.resolveJobId();
+        return new GitHubBodyVars(
+                request.repoForTemplate(),
+                request.resolveBaseBranch(),
+                nullToEmpty(request.branch()),
+                request.shaForTemplate(),
+                nullToEmpty(request.title()),
+                nullToEmpty(request.author()),
+                nullToEmpty(request.date()),
+                GitHubBodyInputTruncator.truncateCommits(request.commitsText()),
+                GitHubBodyInputTruncator.truncateFiles(request.filesText()),
+                jobId,
+                request.deliveryIdForTemplate()
+        );
+    }
+
+    /** Placeholder 이름 → 값 Map (GitHubBodyPlaceholderSubstitutor에서 사용). */
+    public Map<String, String> toMap() {
+        return Stream.of(
+                entry("REPO", repo),
+                entry("BASE_BRANCH", baseBranch),
+                entry("BRANCH", branch),
+                entry("SHA", sha),
+                entry("TITLE", title),
+                entry("AUTHOR", author),
+                entry("DATE", date),
+                entry("COMMITS", commits),
+                entry("FILES", files),
+                entry("JOB_ID", jobId),
+                entry("DELIVERY_ID", deliveryId)
+        ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static Map.Entry<String, String> entry(String k, String v) {
+        return Map.entry(k, v);
+    }
+
+    private static String nullToEmpty(String s) {
+        return s != null ? s : "";
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/github/GitHubBodyRequestDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/request/github/GitHubBodyRequestDto.java
@@ -1,0 +1,86 @@
+package org.example.sharedprompts.module.dto.request.github;
+
+import org.example.sharedprompts.module.exception.BaseException;
+import org.example.sharedprompts.module.exception.ModuleErrorCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Input for generating GitHub Issue and PR body (webhook/API).
+ * jobId / deliveryId / sha 중 하나는 반드시 있어야 하며, resolveJobId() 우선순위: jobId → deliveryId → sha.
+ * 본문 템플릿은 path의 prompts/{promptId} 로 조회.
+ */
+public record GitHubBodyRequestDto(
+        String jobId,
+        String deliveryId,
+        String sha,
+        String repoFullName,
+        String branch,
+        String baseBranch,
+        String title,
+        String author,
+        String date,
+        String commits,
+        String files,
+        String tenantId
+) {
+
+    /** baseBranch가 null/blank면 "main". */
+    public String resolveBaseBranch() {
+        return (baseBranch != null && !baseBranch.isBlank()) ? baseBranch : "main";
+    }
+
+    /**
+     * Job identifier for grouping issue + PR outputs.
+     * 우선순위: jobId → deliveryId → sha. 세 값 모두 없으면 BaseException.
+     */
+    public String resolveJobId() {
+        if (jobId != null && !jobId.isBlank()) return jobId;
+        if (deliveryId != null && !deliveryId.isBlank()) return deliveryId;
+        if (sha != null && !sha.isBlank()) return sha;
+        throw new BaseException(ModuleErrorCode.GITHUB_BODY_JOB_ID_REQUIRED, null,
+                "jobId, deliveryId, sha 중 하나 이상 필요");
+    }
+
+    /** Template용 commits 문자열. */
+    public String commitsText() {
+        return commits != null ? commits : "";
+    }
+
+    /** Template용 files 문자열. */
+    public String filesText() {
+        return files != null ? files : "";
+    }
+
+    /** Template용 repo (repoFullName 또는 빈 문자열). */
+    public String repoForTemplate() {
+        return repoFullName != null ? repoFullName : "";
+    }
+
+    /** Template용 deliveryId. */
+    public String deliveryIdForTemplate() {
+        return deliveryId != null ? deliveryId : "";
+    }
+
+    /** Template용 sha. */
+    public String shaForTemplate() {
+        return sha != null ? sha : "";
+    }
+
+    /** JSON에서 List<String> commits → 단일 문자열로 받기 위한 헬퍼. (Object로 받아서 서비스에서 변환하거나, 커스텀 deserializer 사용 시 활용) */
+    public static String joinIfList(Object commits) {
+        if (commits == null) return "";
+        if (commits instanceof String s) return s;
+        if (commits instanceof List<?> list) {
+            return list.stream().map(String::valueOf).collect(Collectors.joining("\n"));
+        }
+        return commits.toString();
+    }
+
+    /** Used internally when generating Issue vs PR body. */
+    public enum Kind {
+        ISSUE,
+        PR
+    }
+}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/github/GitHubBodyResponseDto.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/dto/response/github/GitHubBodyResponseDto.java
@@ -1,0 +1,12 @@
+package org.example.sharedprompts.module.dto.response.github;
+
+/**
+ * Generated Markdown for both Issue and PR. Stored under the same jobId for DELIVERY.
+ */
+public record GitHubBodyResponseDto(
+        String jobId,
+        String issueBody,
+        String prBody,
+        String storedIssueFileKey,
+        String storedPrFileKey
+) {}

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/module/exception/ModuleErrorCode.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/module/exception/ModuleErrorCode.java
@@ -26,7 +26,9 @@ public enum ModuleErrorCode {
     IDEMPOTENCY_KEY_ERROR("PD01007", HttpStatus.INTERNAL_SERVER_ERROR, "멱등성 키 생성 중 오류가 발생했습니다."),
     AI_CLIENT_ERROR("PD01008", HttpStatus.INTERNAL_SERVER_ERROR, "AI 클라이언트 호출 중 오류가 발생했습니다."),
     UNSUPPORTED_CONTENT_TYPE("PD00405", HttpStatus.BAD_REQUEST, "지원하지 않는 콘텐츠 타입입니다."),
-    JOB_QUEUE_PUBLISH_ERROR("PD01009", HttpStatus.INTERNAL_SERVER_ERROR, "작업 큐 발행 중 오류가 발생했습니다.");
+    JOB_QUEUE_PUBLISH_ERROR("PD01009", HttpStatus.INTERNAL_SERVER_ERROR, "작업 큐 발행 중 오류가 발생했습니다."),
+    GITHUB_BODY_JOB_ID_REQUIRED("PD00406", HttpStatus.BAD_REQUEST, "jobId, deliveryId, sha 중 하나 이상 필요"),
+    GITHUB_BODY_PROMPT_NOT_FOUND("PD00703",HttpStatus.NOT_FOUND ,"gitHub prompt를 찾을 수 없습니다." ),;
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/module/controller/github/GitHubBodyControllerTest.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/module/controller/github/GitHubBodyControllerTest.java
@@ -1,0 +1,79 @@
+package org.example.sharedprompts.module.controller.github;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.sharedprompts.module.domain.github.GitHubBodyGenerateApplicationService;
+import org.example.sharedprompts.module.domain.github.GitHubBodyGeneratorService;
+import org.example.sharedprompts.module.domain.github.GitHubBodyStorageService;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+import org.example.sharedprompts.module.dto.response.github.GitHubBodyResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GitHubBodyController.class)
+@DisplayName("GitHubBodyController 통합 테스트")
+class GitHubBodyControllerTest {
+
+    private static final Long PROMPT_ID = 1L;
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private GitHubBodyGenerateApplicationService applicationService;
+    @MockBean
+    private GitHubBodyGeneratorService generatorService;
+    @MockBean
+    private GitHubBodyStorageService storageService;
+
+    @Test
+    @DisplayName("POST /prompts/{promptId}/github/bodies/generate - jobId 있으면 생성 후 200 + body + keys")
+    void generate_returnsBodiesAndKeys() throws Exception {
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "job-1", null, null, "owner/repo", "main", null,
+                "title", null, null, "commits", "files", null);
+        var response = new GitHubBodyResponseDto("job-1", "# Issue", "# PR", "s3/issue.md", "s3/pr.md");
+        when(applicationService.generate(eq(PROMPT_ID), any())).thenReturn(response);
+
+        mockMvc.perform(post("/prompts/{promptId}/github/bodies/generate", PROMPT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.jobId").value("job-1"))
+                .andExpect(jsonPath("$.data.issueBody").value("# Issue"))
+                .andExpect(jsonPath("$.data.prBody").value("# PR"))
+                .andExpect(jsonPath("$.data.storedIssueFileKey").value("s3/issue.md"))
+                .andExpect(jsonPath("$.data.storedPrFileKey").value("s3/pr.md"));
+
+        verify(applicationService).generate(eq(PROMPT_ID), any());
+    }
+
+    @Test
+    @DisplayName("jobId/deliveryId/sha 모두 없으면 400")
+    void generate_missingJobId_returns400() throws Exception {
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                null, null, null, null, null, null, null, null, null, null, null, null);
+
+        mockMvc.perform(post("/prompts/{promptId}/github/bodies/generate", PROMPT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/module/domain/github/GitHubBodyGeneratorServiceTest.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/module/domain/github/GitHubBodyGeneratorServiceTest.java
@@ -1,0 +1,48 @@
+package org.example.sharedprompts.module.domain.github;
+
+import org.example.sharedprompts.module.domain.production.service.ai.text.TextAiClient;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GitHubBodyGeneratorService 프롬프트 치환 및 generateBoth 테스트")
+class GitHubBodyGeneratorServiceTest {
+
+    @Test
+    @DisplayName("TextAiClient 없을 때 템플릿 치환으로 Issue/PR 본문 생성")
+    void generateBoth_withoutAiClient_usesTemplateSubstitution() {
+        GitHubBodyGeneratorService service = new GitHubBodyGeneratorService(null);
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "job-1", "delivery-1", "abc123",
+                "owner/repo", "feature/x", "main",
+                "feat: add api", "dev", "2025-02-23",
+                "commit message line 1", "src/A.java",
+                "github");
+
+        GitHubBodyGeneratorService.GitHubBodyPair pair = service.generateBoth(request);
+
+        assertThat(pair.issueBody()).contains("owner/repo").contains("abc123").contains("job-1");
+        assertThat(pair.issueBody()).contains("[AUTO_JOB_ID:job-1]").contains("[AUTO_PUSH_DELIVERY:delivery-1]").contains("[AUTO_PUSH_SHA:abc123]");
+        assertThat(pair.prBody()).contains("owner/repo").contains("main").contains("feature/x");
+        assertThat(pair.prBody()).contains("[AUTO_JOB_ID:job-1]");
+    }
+
+    @Test
+    @DisplayName("Mock Groq 응답 시 치환된 본문 반환")
+    void generateBody_withMockGroq_substitutesPlaceholders() {
+        TextAiClient mockClient = (prompt, modelName, contentTypeHint) ->
+                "## TL;DR\n- Summary from AI.\n\n## Links\n- https://github.com/{{REPO}}/commit/{{SHA}}\n\n[AUTO_JOB_ID:{{JOB_ID}}]\n[AUTO_PUSH_DELIVERY:{{DELIVERY_ID}}]\n[AUTO_PUSH_SHA:{{SHA}}]";
+        GitHubBodyGeneratorService service = new GitHubBodyGeneratorService(mockClient);
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "job-2", "del-2", "sha-2",
+                "org/repo", "main", null,
+                "title", "a", "d", "c", "f", null);
+
+        String body = service.generateBody(request, GitHubBodyRequestDto.Kind.ISSUE);
+
+        assertThat(body).contains("org/repo").contains("sha-2").contains("job-2").contains("del-2");
+        assertThat(body).contains("[AUTO_JOB_ID:job-2]").contains("[AUTO_PUSH_DELIVERY:del-2]").contains("[AUTO_PUSH_SHA:sha-2]");
+    }
+}

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/module/domain/github/GitHubBodyInputTruncatorTest.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/module/domain/github/GitHubBodyInputTruncatorTest.java
@@ -1,0 +1,37 @@
+package org.example.sharedprompts.module.domain.github;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GitHubBodyInputTruncator 입력 크기 제한 테스트")
+class GitHubBodyInputTruncatorTest {
+
+    @Test
+    @DisplayName("commits 50줄 초과 시 앞 50줄 + ... and N more")
+    void truncateCommits_over50_truncates() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 60; i++) sb.append("line").append(i).append("\n");
+        String result = GitHubBodyInputTruncator.truncateCommits(sb.toString());
+        assertThat(result.split("\n").length).isEqualTo(51); // 50 lines + "... and 10 more"
+        assertThat(result).contains("... and 10 more");
+    }
+
+    @Test
+    @DisplayName("files 200줄 초과 시 앞 200줄 + ... and N more")
+    void truncateFiles_over200_truncates() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 250; i++) sb.append("f").append(i).append("\n");
+        String result = GitHubBodyInputTruncator.truncateFiles(sb.toString());
+        assertThat(result.split("\n").length).isEqualTo(201);
+        assertThat(result).contains("... and 50 more");
+    }
+
+    @Test
+    @DisplayName("50줄 이하면 그대로 반환")
+    void truncateCommits_underLimit_unchanged() {
+        String text = "a\nb\nc";
+        assertThat(GitHubBodyInputTruncator.truncateCommits(text)).isEqualTo(text);
+    }
+}

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/module/domain/github/GitHubBodyStorageServiceTest.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/module/domain/github/GitHubBodyStorageServiceTest.java
@@ -1,0 +1,114 @@
+package org.example.sharedprompts.module.domain.github;
+
+import org.example.sharedprompts.module.domain.production.application.storage.StorageFacade;
+import org.example.sharedprompts.module.domain.production.infra.storage.S3KeyGenerator;
+import org.example.sharedprompts.module.dto.request.github.GitHubBodyRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GitHubBodyStorageService 키 생성 규칙 및 tryGetExisting 테스트")
+class GitHubBodyStorageServiceTest {
+
+    @Mock
+    private StorageFacade storageFacade;
+    @Mock
+    private S3KeyGenerator keyGenerator;
+
+    @Test
+    @DisplayName("tryGetExistingKeys: 둘 다 존재하면 StoredKeys 반환")
+    void tryGetExistingKeys_bothExist_returnsKeys() {
+        when(keyGenerator.generateKey(eq("github"), eq(0L), eq("job-1"), eq("issue-job-1.md")))
+                .thenReturn("production/github/0/job-1/issue-job-1.md");
+        when(keyGenerator.generateKey(eq("github"), eq(0L), eq("job-1"), eq("pr-job-1.md")))
+                .thenReturn("production/github/0/job-1/pr-job-1.md");
+        when(storageFacade.exists("production/github/0/job-1/issue-job-1.md")).thenReturn(true);
+        when(storageFacade.exists("production/github/0/job-1/pr-job-1.md")).thenReturn(true);
+
+        GitHubBodyStorageService service = new GitHubBodyStorageService(storageFacade, keyGenerator);
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "job-1", null, null, null, null, null, null, null, null, null, null, null);
+
+        Optional<GitHubBodyStorageService.StoredKeys> result = service.tryGetExistingKeys(request);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().storedIssueFileKey()).isEqualTo("production/github/0/job-1/issue-job-1.md");
+        assertThat(result.get().storedPrFileKey()).isEqualTo("production/github/0/job-1/pr-job-1.md");
+    }
+
+    @Test
+    @DisplayName("저장 키 규칙: prefix/tenantId/0/jobId/fileName 형식")
+    void keyFormat_prefix_tenantId_zero_jobId_fileName() {
+        when(keyGenerator.generateKey(eq("github"), eq(0L), eq("abc123"), eq("issue-abc123.md")))
+                .thenReturn("production/github/0/abc123/issue-abc123.md");
+        when(keyGenerator.generateKey(eq("github"), eq(0L), eq("abc123"), eq("pr-abc123.md")))
+                .thenReturn("production/github/0/abc123/pr-abc123.md");
+        when(storageFacade.exists(anyString())).thenReturn(true);
+
+        GitHubBodyStorageService service = new GitHubBodyStorageService(storageFacade, keyGenerator);
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "abc123", null, null, null, null, null, null, null, null, null, null, "github");
+
+        Optional<GitHubBodyStorageService.StoredKeys> result = service.tryGetExistingKeys(request);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().storedIssueFileKey()).startsWith("production/").contains("github/0/abc123/").endsWith("issue-abc123.md");
+        assertThat(result.get().storedPrFileKey()).startsWith("production/").contains("github/0/abc123/").endsWith("pr-abc123.md");
+    }
+
+    @Test
+    @DisplayName("PR 저장 실패 시 보상: 이미 저장된 issue 파일 delete 호출")
+    void saveBothAsMarkdown_prFails_compensationDeleteIssue() {
+        when(storageFacade.upload(anyString(), eq("github"), eq(0L), eq("j1"), eq("issue-j1.md")))
+                .thenReturn("production/github/0/j1/issue-j1.md");
+        when(storageFacade.upload(anyString(), eq("github"), eq(0L), eq("j1"), eq("pr-j1.md")))
+                .thenThrow(new RuntimeException("S3 pr upload failed"));
+
+        GitHubBodyStorageService service = new GitHubBodyStorageService(storageFacade, keyGenerator);
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "j1", null, null, null, null, null, null, null, null, null, null, "github");
+
+        assertThatThrownBy(() -> service.saveBothAsMarkdown("issue", "pr", request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("S3 pr upload failed");
+
+        verify(storageFacade).delete("production/github/0/j1/issue-j1.md");
+    }
+
+    @Test
+    @DisplayName("tryGetExistingKeys: 하나라도 없으면 empty")
+    void tryGetExistingKeys_oneMissing_returnsEmpty() {
+        when(keyGenerator.generateKey(anyString(), eq(0L), anyString(), anyString()))
+                .thenReturn("production/github/0/j1/issue-j1.md")
+                .thenReturn("production/github/0/j1/pr-j1.md");
+        when(storageFacade.exists("production/github/0/j1/issue-j1.md")).thenReturn(true);
+        when(storageFacade.exists("production/github/0/j1/pr-j1.md")).thenReturn(false);
+
+        GitHubBodyStorageService service = new GitHubBodyStorageService(storageFacade, keyGenerator);
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "j1", null, null, null, null, null, null, null, null, null, null, null);
+
+        assertThat(service.tryGetExistingKeys(request)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("StorageFacade null이면 tryGetExistingKeys empty")
+    void tryGetExistingKeys_noFacade_returnsEmpty() {
+        GitHubBodyStorageService service = new GitHubBodyStorageService(null, keyGenerator);
+        GitHubBodyRequestDto request = new GitHubBodyRequestDto(
+                "j1", null, null, null, null, null, null, null, null, null, null, null);
+        assertThat(service.tryGetExistingKeys(request)).isEmpty();
+    }
+}

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/module/dto/request/github/GitHubBodyRequestDtoTest.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/module/dto/request/github/GitHubBodyRequestDtoTest.java
@@ -1,0 +1,59 @@
+package org.example.sharedprompts.module.dto.request.github;
+
+import org.example.sharedprompts.module.exception.BaseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("GitHubBodyRequestDto resolveJobId 우선순위 테스트")
+class GitHubBodyRequestDtoTest {
+
+    @ParameterizedTest(name = "jobId={0}, deliveryId={1}, sha={2} → expect {3}")
+    @CsvSource({
+            "j1, d1, s1, j1",
+            "j1, d1, '', j1",
+            "j1, '', s1, j1",
+            "j1, '', '', j1",
+            "'', d1, s1, d1",
+            "'', d1, '', d1",
+            "'', '', s1, s1",
+    })
+    @DisplayName("resolveJobId 우선순위: jobId > deliveryId > sha")
+    void resolveJobId_priority(String jobId, String deliveryId, String sha, String expected) {
+        GitHubBodyRequestDto dto = new GitHubBodyRequestDto(
+                blankToNull(jobId), blankToNull(deliveryId), blankToNull(sha),
+                null, null, null, null, null, null, null, null, null);
+        assertThat(dto.resolveJobId()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("jobId, deliveryId, sha 모두 없으면 BaseException")
+    void resolveJobId_allMissing_throws() {
+        GitHubBodyRequestDto dto = new GitHubBodyRequestDto(
+                null, null, null, null, null, null, null, null, null, null, null, null);
+
+        assertThatThrownBy(dto::resolveJobId)
+                .isInstanceOf(BaseException.class)
+                .hasMessageContaining("jobId, deliveryId, sha 중 하나 이상 필요");
+    }
+
+    @Test
+    @DisplayName("resolveBaseBranch: null/blank면 main")
+    void resolveBaseBranch_defaultMain() {
+        GitHubBodyRequestDto dto = new GitHubBodyRequestDto(
+                "j", null, null, null, null, null, null, null, null, null, null, null);
+        assertThat(dto.resolveBaseBranch()).isEqualTo("main");
+
+        GitHubBodyRequestDto withBase = new GitHubBodyRequestDto(
+                "j", null, null, null, null, "develop", null, null, null, null, null, null);
+        assertThat(withBase.resolveBaseBranch()).isEqualTo("develop");
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s.trim();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- GitHub 이슈 및 PR 마크다운 본문을 자동으로 생성하는 새로운 API 엔드포인트 추가
- 생성된 콘텐츠를 S3에 저장하고 저장된 파일 위치 정보를 응답으로 반환
- 동일한 요청에 대한 멱등성 지원으로 불필요한 중복 생성 방지
- 커밋 및 파일 입력값의 자동 축약 기능으로 대용량 입력 처리
- 실패 시 자동 보상 메커니즘으로 데이터 일관성 보장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->