### PR TITLE
feat(policy): wire objective mapping to heuristic inference fallback

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/DefaultObjectiveHeuristicInferencePolicy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/DefaultObjectiveHeuristicInferencePolicy.java
@@ -1,0 +1,89 @@
+package org.example.sharedprompts.domain.prompt.domain.resolutions;
+
+import org.example.sharedprompts.domain.prompt.common.enums.action.ActionTypeInterface;
+import org.example.sharedprompts.domain.prompt.domain.value.objective.PromptObjective;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Default heuristic inference:
+ * exact keyword match first, then partial containment fallback.
+ */
+public class DefaultObjectiveHeuristicInferencePolicy implements ObjectiveHeuristicInferencePolicy {
+
+    private static final Map<PromptObjective, Set<String>> KEYWORD_MAP;
+
+    static {
+        Map<PromptObjective, Set<String>> m = new LinkedHashMap<>();
+        m.put(PromptObjective.EXTRACTION, Set.of(
+                "EXTRACT", "EXTRACTION", "PARSE", "JSON", "SCHEMA",
+                "STRUCTURE", "NORMALIZE", "TAG", "LABEL", "CLASSIFY",
+                "KEY_VALUE", "FIELDS", "MAPPING", "REGEX", "PATTERN_EXTRACT"
+        ));
+        m.put(PromptObjective.FACTUAL, Set.of(
+                "SUMMARIZE", "SUMMARY", "TLDR", "ABSTRACT",
+                "TRANSLATE", "TRANSLATION",
+                "REWRITE", "PARAPHRASE", "POLISH", "PROOFREAD",
+                "GRAMMAR", "SPELL", "CLEANUP",
+                "FORMAT", "CONVERT", "TRANSFORM",
+                "MINUTES", "MEETING_NOTES",
+                "DATA_SUMMARY", "REPORT", "DOCUMENTATION"
+        ));
+        m.put(PromptObjective.ANALYTICAL, Set.of(
+                "COMPARE", "COMPARISON", "EVALUATE", "EVALUATION",
+                "REVIEW", "CRITIQUE", "PROS_CONS",
+                "RISK", "TRADEOFF", "BENCHMARK",
+                "ROOT_CAUSE", "DIAGNOSE", "ANALYZE", "ANALYSIS"
+        ));
+        m.put(PromptObjective.PLANNING, Set.of(
+                "PLAN", "PLANNING", "ROADMAP", "STRATEGY",
+                "OUTLINE", "STRUCTURE_PLAN", "CHECKLIST",
+                "SPEC", "REQUIREMENTS", "DESIGN", "ARCHITECTURE",
+                "MIGRATION", "REFACTOR_PLAN",
+                "TASK_BREAKDOWN", "STEPS", "WORKFLOW"
+        ));
+        m.put(PromptObjective.CREATIVE_WITH_CONSTRAINTS, Set.of(
+                "DRAFT", "WRITE", "GENERATE", "CREATE", "COMPOSE",
+                "BRAINSTORM", "IDEATE",
+                "STORY", "POEM", "SCRIPT",
+                "MARKETING_COPY", "COPY", "SLOGAN",
+                "TITLE", "HEADLINE",
+                "CHARACTER", "SCENE"
+        ));
+        m.put(PromptObjective.REASONING, Set.of(
+                "EXPLAIN", "TEACH", "TUTOR", "WHY", "HOW",
+                "DEBUG", "TROUBLESHOOT", "FIX",
+                "SOLVE", "PROBLEM_SOLVING", "DERIVE",
+                "CODE_REVIEW", "REFACTOR", "OPTIMIZE",
+                "ALGORITHM", "IMPLEMENT", "INTEGRATE"
+        ));
+        KEYWORD_MAP = Map.copyOf(m);
+    }
+
+    @Override
+    public Optional<PromptObjective> inferByActionName(ActionTypeInterface actionType) {
+        if (actionType == null) return Optional.empty();
+        String name = String.valueOf(actionType).trim().toUpperCase();
+        if (name.isEmpty()) return Optional.empty();
+
+        // 1) exact match first (e.g. CODE_REVIEW)
+        for (Map.Entry<PromptObjective, Set<String>> entry : KEYWORD_MAP.entrySet()) {
+            if (entry.getValue().contains(name)) {
+                return Optional.of(entry.getKey());
+            }
+        }
+        // 2) partial match fallback
+        for (Map.Entry<PromptObjective, Set<String>> entry : KEYWORD_MAP.entrySet()) {
+            for (String keyword : entry.getValue()) {
+                if (name.contains(keyword)) {
+                    return Optional.of(entry.getKey());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/DefaultObjectiveHeuristicInferencePolicy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/DefaultObjectiveHeuristicInferencePolicy.java
@@ -66,7 +66,8 @@ public class DefaultObjectiveHeuristicInferencePolicy implements ObjectiveHeuris
     @Override
     public Optional<PromptObjective> inferByActionName(ActionTypeInterface actionType) {
         if (actionType == null) return Optional.empty();
-        String name = String.valueOf(actionType).trim().toUpperCase();
+        if (!(actionType instanceof Enum<?> e)) return Optional.empty();
+        String name = e.name().trim().toUpperCase();
         if (name.isEmpty()) return Optional.empty();
 
         // 1) exact match first (e.g. CODE_REVIEW)

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/ObjectiveHeuristicInferencePolicy.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/ObjectiveHeuristicInferencePolicy.java
@@ -1,0 +1,24 @@
+package org.example.sharedprompts.domain.prompt.domain.resolutions;
+
+import org.example.sharedprompts.domain.prompt.domain.value.objective.PromptObjective;
+import org.example.sharedprompts.domain.prompt.common.enums.action.ActionTypeInterface;
+
+import java.util.Optional;
+
+/**
+ * Objective inference from action name (heuristic fallback).
+ *
+ * <p>Registry owns overlay + policy-source lookup; this policy owns "keyword mapping" and
+ * action-name matching rules so it can be swapped/extended independently.
+ */
+public interface ObjectiveHeuristicInferencePolicy {
+
+    /**
+     * Infer an objective from the action type name (heuristic).
+     *
+     * @param actionType action type (null-safe)
+     * @return matched objective; empty when no heuristic matches
+     */
+    Optional<PromptObjective> inferByActionName(ActionTypeInterface actionType);
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/ObjectiveMappingRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/ObjectiveMappingRegistry.java
@@ -1,78 +1,34 @@
 package org.example.sharedprompts.domain.prompt.domain.resolutions;
 
-import org.example.sharedprompts.domain.prompt.domain.value.objective.PromptObjective;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.objective.ObjectivePolicySource;
+import org.example.sharedprompts.domain.prompt.domain.value.objective.PromptObjective;
 import org.example.sharedprompts.domain.prompt.common.enums.semantic.TaskDomain;
 import org.example.sharedprompts.domain.prompt.common.enums.action.ActionTypeInterface;
-import org.example.sharedprompts.domain.prompt.common.enums.action.canonical.CanonicalActionRegistry;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
 
 /**
  * Adapter: {@link ObjectiveMappingRegistryPort} implemented using {@link ObjectivePolicySource}.
- * Explicit mapping and domain default come from the policy source; heuristic remains here for fallback.
- * Config must not hold raw maps; wire {@link ObjectivePolicySource} (e.g. {@link org.example.sharedprompts.domain.prompt.domain.semantic.policy.objective.DefaultObjectivePolicySource}).
+ * Explicit mapping and domain default come from the policy source; heuristic fallback is delegated to
+ * {@link ObjectiveHeuristicInferencePolicy}.
+ * Config must not hold raw maps; wire {@link ObjectivePolicySource} (e.g. {@link org.example.sharedprompts.domain.prompt.domain.semantic.policy.objective.DefaultObjectivePolicySource})
+ * and {@link ObjectiveHeuristicInferencePolicy} (e.g. {@link DefaultObjectiveHeuristicInferencePolicy}).
  */
 public class ObjectiveMappingRegistry implements ObjectiveMappingRegistryPort {
 
     private final ObjectivePolicySource policySource;
+    private final ObjectiveHeuristicInferencePolicy heuristicInferencePolicy;
     /** Optional overlay (e.g. tests); checked before policy source. */
     private final Map<String, PromptObjective> overlayByStableKey = new ConcurrentHashMap<>();
 
-    private static final Map<PromptObjective, Set<String>> KEYWORD_MAP;
-
-    static {
-        KEYWORD_MAP = new LinkedHashMap<>();
-        KEYWORD_MAP.put(PromptObjective.EXTRACTION, Set.of(
-                "EXTRACT", "EXTRACTION", "PARSE", "JSON", "SCHEMA",
-                "STRUCTURE", "NORMALIZE", "TAG", "LABEL", "CLASSIFY",
-                "KEY_VALUE", "FIELDS", "MAPPING", "REGEX", "PATTERN_EXTRACT"
-        ));
-        KEYWORD_MAP.put(PromptObjective.FACTUAL, Set.of(
-                "SUMMARIZE", "SUMMARY", "TLDR", "ABSTRACT",
-                "TRANSLATE", "TRANSLATION",
-                "REWRITE", "PARAPHRASE", "POLISH", "PROOFREAD",
-                "GRAMMAR", "SPELL", "CLEANUP",
-                "FORMAT", "CONVERT", "TRANSFORM",
-                "MINUTES", "MEETING_NOTES",
-                "DATA_SUMMARY", "REPORT", "DOCUMENTATION"
-        ));
-        KEYWORD_MAP.put(PromptObjective.ANALYTICAL, Set.of(
-                "COMPARE", "COMPARISON", "EVALUATE", "EVALUATION",
-                "REVIEW", "CRITIQUE", "PROS_CONS",
-                "RISK", "TRADEOFF", "BENCHMARK",
-                "ROOT_CAUSE", "DIAGNOSE", "ANALYZE", "ANALYSIS"
-        ));
-        KEYWORD_MAP.put(PromptObjective.PLANNING, Set.of(
-                "PLAN", "PLANNING", "ROADMAP", "STRATEGY",
-                "OUTLINE", "STRUCTURE_PLAN", "CHECKLIST",
-                "SPEC", "REQUIREMENTS", "DESIGN", "ARCHITECTURE",
-                "MIGRATION", "REFACTOR_PLAN",
-                "TASK_BREAKDOWN", "STEPS", "WORKFLOW"
-        ));
-        KEYWORD_MAP.put(PromptObjective.CREATIVE_WITH_CONSTRAINTS, Set.of(
-                "DRAFT", "WRITE", "GENERATE", "CREATE", "COMPOSE",
-                "BRAINSTORM", "IDEATE",
-                "STORY", "POEM", "SCRIPT",
-                "MARKETING_COPY", "COPY", "SLOGAN",
-                "TITLE", "HEADLINE",
-                "CHARACTER", "SCENE"
-        ));
-        KEYWORD_MAP.put(PromptObjective.REASONING, Set.of(
-                "EXPLAIN", "TEACH", "TUTOR", "WHY", "HOW",
-                "DEBUG", "TROUBLESHOOT", "FIX",
-                "SOLVE", "PROBLEM_SOLVING", "DERIVE",
-                "CODE_REVIEW", "REFACTOR", "OPTIMIZE",
-                "ALGORITHM", "IMPLEMENT", "INTEGRATE"
-        ));
-    }
-
-    public ObjectiveMappingRegistry(CanonicalActionRegistry canonicalActionRegistry, ObjectivePolicySource policySource) {
-        this.policySource = policySource;
+    public ObjectiveMappingRegistry(
+            ObjectivePolicySource policySource,
+            ObjectiveHeuristicInferencePolicy heuristicInferencePolicy) {
+        this.policySource = Objects.requireNonNull(policySource, "policySource");
+        this.heuristicInferencePolicy = Objects.requireNonNull(heuristicInferencePolicy, "heuristicInferencePolicy");
     }
 
     /** Test/config overlay: add explicit mapping by stable key without changing policy source. */
@@ -101,33 +57,11 @@ public class ObjectiveMappingRegistry implements ObjectiveMappingRegistryPort {
         if (fromOverlay.isPresent()) return fromOverlay;
         Optional<PromptObjective> fromSource = policySource.findByStableKey(key);
         if (fromSource.isPresent()) return fromSource;
-        return Optional.ofNullable(inferByActionName(actionType));
+        return heuristicInferencePolicy.inferByActionName(actionType);
     }
 
     @Override
     public PromptObjective getDomainDefault(TaskDomain taskDomain) {
         return policySource.getDomainDefault(taskDomain);
-    }
-
-    private PromptObjective inferByActionName(ActionTypeInterface actionType) {
-        String name = String.valueOf(actionType).trim().toUpperCase();
-        if (name.isEmpty()) {
-            return null;
-        }
-        // 1) 정확 매칭 우선 (예: CODE_REVIEW)
-        for (Map.Entry<PromptObjective, Set<String>> entry : KEYWORD_MAP.entrySet()) {
-            if (entry.getValue().contains(name)) {
-                return entry.getKey();
-            }
-        }
-        // 2) 부분 매칭 fallback
-        for (Map.Entry<PromptObjective, Set<String>> entry : KEYWORD_MAP.entrySet()) {
-            for (String keyword : entry.getValue()) {
-                if (name.contains(keyword)) {
-                    return entry.getKey();
-                }
-            }
-        }
-        return null;
     }
 }

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/ObjectiveMappingRegistryPort.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/resolutions/ObjectiveMappingRegistryPort.java
@@ -7,11 +7,11 @@ import org.example.sharedprompts.domain.prompt.common.enums.action.ActionTypeInt
 import java.util.Optional;
 
 /**
- * Objective 해석 fallback: 액션 휴리스틱 + TaskDomain 기본값 (도메인 내부 전략).
+ * Objective 해석 fallback: action 휴리스틱 + TaskDomain 기본값.
  *
  * <p>명시 매핑 이후 fallback으로만 사용.
  *
- * <p><b>내부 전략.</b> 구현: {@link ObjectiveMappingRegistry}.
+ * <p><b>내부 전략.</b> 구현: {@link ObjectiveMappingRegistry} (휴리스틱은 {@link ObjectiveHeuristicInferencePolicy}로 위임).
  */
 public interface ObjectiveMappingRegistryPort {
 

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/infrastructure/config/ResolutionConfig.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/infrastructure/config/ResolutionConfig.java
@@ -19,8 +19,10 @@ import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommenda
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.registry.PolicySourceRegistry;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.version.PolicyVersion;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.DomainResolverPort;
+import org.example.sharedprompts.domain.prompt.domain.resolutions.DefaultObjectiveHeuristicInferencePolicy;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveMappingRegistry;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveMappingRegistryPort;
+import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveHeuristicInferencePolicy;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveResolver;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveResolverPort;
 import org.springframework.context.annotation.Bean;
@@ -58,10 +60,15 @@ public class ResolutionConfig {
     }
 
     @Bean
+    public ObjectiveHeuristicInferencePolicy objectiveHeuristicInferencePolicy() {
+        return new DefaultObjectiveHeuristicInferencePolicy();
+    }
+
+    @Bean
     public ObjectiveMappingRegistryPort objectiveMappingRegistry(
-            CanonicalActionRegistry canonicalActionRegistry,
-            ObjectivePolicySource objectivePolicySource) {
-        return new ObjectiveMappingRegistry(canonicalActionRegistry, objectivePolicySource);
+            ObjectivePolicySource objectivePolicySource,
+            ObjectiveHeuristicInferencePolicy heuristicInferencePolicy) {
+        return new ObjectiveMappingRegistry(objectivePolicySource, heuristicInferencePolicy);
     }
 
     @Bean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 액션 이름 기반 목표(Objective) 추론 로직을 모듈화된 히리스틱 정책으로 분리해 구조를 개선했습니다.
  * 표준 히리스틱 구현이 추가되어 기존 레지스트리가 해당 정책으로 추론을 위임하도록 변경되었습니다.
  * 구성(설정)에서 새 히리스틱 정책을 빈으로 등록해 유연한 교체와 테스트가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->