### PR TITLE
feat(semantic): introduce intent definitions and resolution defaults

### DIFF
--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentAnalysisIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentAnalysisIntentDefinitionsProvider.java
@@ -1,0 +1,91 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentAnalysisIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.ANALYZE,
+                        new IntentDefinition(
+                                ActionIntent.ANALYZE,
+                                "Break down a subject into components, patterns, or factors; systematic examination.",
+                                "User wants understanding of parts, causes, or patterns in data, text, or a system.",
+                                "When the goal is judgment of merit (use EVALUATE), comparison (use COMPARE), or fault-finding (use DIAGNOSE).",
+                                "ANALYZE = break down and examine; EVALUATE = judge merit; CRITIQUE = judge with standards; DIAGNOSE = find cause of problem.",
+                                "Structured analysis; components, factors, or patterns.",
+                                List.of(PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS, PromptCategory.RESEARCH, PromptCategory.BUSINESS),
+                                List.of("DATA_ANALYSIS", "LITERATURE_REVIEW", "ROOT_CAUSE_ANALYSIS"),
+                                List.of("GENERAL_CONSULTANT", "RESEARCHER", "BUSINESS_ANALYST_BUSINESS"),
+                                "Core intent for ANALYSIS and RESEARCH categories."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.EVALUATE,
+                        new IntentDefinition(
+                                ActionIntent.EVALUATE,
+                                "Judge merit, quality, or suitability against criteria or goals.",
+                                "User wants an assessment of how good, suitable, or effective something is.",
+                                "When the goal is only to break down or describe (use ANALYZE) or to compare two things (use COMPARE).",
+                                "EVALUATE = judge merit; ANALYZE = examine components; CRITIQUE = evaluate against explicit standards; COMPARE = compare alternatives.",
+                                "Structured evaluation with criteria and judgment.",
+                                List.of(PromptCategory.DESIGN, PromptCategory.DEVELOPMENT, PromptCategory.RESEARCH),
+                                List.of("CODE_REVIEW", "UX_DESIGN", "COMPARATIVE_ANALYSIS"),
+                                List.of("UI_UX_DESIGNER", "PRODUCT_DESIGNER", "RESEARCHER"),
+                                "DESIGN: preferred for design review and critique flows."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.COMPARE,
+                        new IntentDefinition(
+                                ActionIntent.COMPARE,
+                                "Place two or more items side by side; highlight similarities and differences.",
+                                "User wants a direct comparison of options, versions, or alternatives.",
+                                "When the goal is single-item analysis (ANALYZE) or a merit judgment (EVALUATE).",
+                                "COMPARE = side-by-side comparison; ANALYZE = single subject breakdown; EVALUATE = merit judgment.",
+                                "Structured comparison; pros/cons or dimension-based.",
+                                List.of(PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS, PromptCategory.BUSINESS, PromptCategory.RESEARCH),
+                                List.of("COMPARATIVE_ANALYSIS", "DATA_ANALYSIS"),
+                                List.of("BUSINESS_ANALYST_BUSINESS", "RESEARCHER"),
+                                "Fits ANALYSIS and RESEARCH; often used with DECIDE or RECOMMEND."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.CRITIQUE,
+                        new IntentDefinition(
+                                ActionIntent.CRITIQUE,
+                                "Judge against explicit standards or criteria; constructive criticism.",
+                                "User wants feedback that evaluates against defined standards (e.g. design principles, style guide).",
+                                "When the goal is neutral analysis (ANALYZE) or open-ended evaluation without standards (EVALUATE).",
+                                "CRITIQUE = judge against standards; EVALUATE = general merit; ANALYZE = break down without judgment.",
+                                "Structured critique with criteria and suggestions.",
+                                List.of(PromptCategory.DESIGN, PromptCategory.WRITING, PromptCategory.RESEARCH),
+                                List.of("UI_DESIGN", "UX_DESIGN", "EDITING"),
+                                List.of("UI_UX_DESIGNER", "PRODUCT_DESIGNER", "EDITOR"),
+                                "DESIGN: preferred for design review; DIAGNOSE only in narrow debug/critique contexts."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.DIAGNOSE,
+                        new IntentDefinition(
+                                ActionIntent.DIAGNOSE,
+                                "Identify cause of a problem or failure; root-cause or fault-finding.",
+                                "User has a problem (bug, failure, issue) and wants to understand why it occurs.",
+                                "When the goal is general analysis (ANALYZE), merit evaluation (EVALUATE), or design critique (CRITIQUE).",
+                                "DIAGNOSE = find cause of problem; ANALYZE = general breakdown; CRITIQUE = judge against standards.",
+                                "Step-by-step or structured diagnosis; cause-and-effect.",
+                                List.of(PromptCategory.DEVELOPMENT, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
+                                List.of("DEBUGGING", "CODE_ANALYSIS", "ROOT_CAUSE_ANALYSIS"),
+                                List.of("BACKEND_DEVELOPER", "FRONTEND_DEVELOPER"),
+                                "DESIGN: discouraged unless critique/debug context is explicit (e.g. usability bug)."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentAnalysisIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentAnalysisIntentResolutionDefaultsProvider.java
@@ -1,0 +1,38 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentAnalysisIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.ANALYZE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.EVALUATE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.COMPARE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.CRITIQUE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.DIAGNOSE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STEP_BY_STEP)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentCreationIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentCreationIntentDefinitionsProvider.java
@@ -1,0 +1,61 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentCreationIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.CREATE,
+                        new IntentDefinition(
+                                ActionIntent.CREATE,
+                                "Author new artifact from scratch; emphasis on original composition and ownership.",
+                                "User wants to author something new (document, design, piece of content) where originality and structure matter.",
+                                "When the goal is to produce output quickly from a spec (use GENERATE) or to list ideas without a single artifact (use BRAINSTORM).",
+                                "CREATE = original authored composition; GENERATE = produce requested output (may be template-driven); BRAINSTORM = ideation, multiple options.",
+                                "Narrative or structured new artifact; single coherent output.",
+                                List.of(PromptCategory.DESIGN, PromptCategory.WRITING, PromptCategory.CONTENT_CREATION, PromptCategory.CREATIVE),
+                                List.of("UI_DESIGN", "UX_DESIGNER", "ARTICLE_WRITING", "CONTENT_CREATION"),
+                                List.of("UI_UX_DESIGNER", "CONTENT_WRITER", "CREATIVE_DIRECTOR"),
+                                "In CONTENT: prefer CREATE for long-form authored pieces; GENERATE for quick posts or templated output."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.GENERATE,
+                        new IntentDefinition(
+                                ActionIntent.GENERATE,
+                                "Produce requested output from a description or spec; emphasis on fulfilling the request efficiently.",
+                                "User wants the system to produce something (code, copy, design, list) that matches a given description or template.",
+                                "When the user explicitly wants original authorship or heavy creative ownership (use CREATE).",
+                                "GENERATE = produce to spec; CREATE = author from scratch with stronger creative control.",
+                                "Narrative or structured output matching the request; may be more template- or spec-driven than CREATE.",
+                                List.of(PromptCategory.DEVELOPMENT, PromptCategory.CONTENT_CREATION, PromptCategory.MARKETING, PromptCategory.CREATIVE),
+                                List.of("CODE_GENERATION", "CONTENT_CREATION", "CONTENT_MARKETING"),
+                                List.of("FULL_STACK_DEVELOPER", "CONTENT_CREATOR", "DIGITAL_MARKETER"),
+                                "Default fallback for many categories when intent is unspecified."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.BRAINSTORM,
+                        new IntentDefinition(
+                                ActionIntent.BRAINSTORM,
+                                "Generate multiple ideas, options, or directions without committing to a single artifact.",
+                                "User wants ideation, alternatives, or exploratory options rather than one final deliverable.",
+                                "When the user wants a single concrete output (use CREATE or GENERATE).",
+                                "BRAINSTORM = many ideas; CREATE/GENERATE = one deliverable.",
+                                "Structured list or short descriptions of options; no single narrative.",
+                                List.of(PromptCategory.CREATIVE, PromptCategory.BUSINESS, PromptCategory.DESIGN),
+                                List.of("IDEA_GENERATION", "CREATIVE_WRITING"),
+                                List.of("CREATIVE_DIRECTOR", "MARKETING_STRATEGIST"),
+                                "Often pairs with CREATIVE or BUSINESS; less common in DEVELOPMENT for code."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentCreationIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentCreationIntentResolutionDefaultsProvider.java
@@ -1,0 +1,30 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentCreationIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.CREATE,
+                        new IntentResolutionDefaults(PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.NARRATIVE)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.GENERATE,
+                        new IntentResolutionDefaults(PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.NARRATIVE)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.BRAINSTORM,
+                        new IntentResolutionDefaults(PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDecisionIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDecisionIntentDefinitionsProvider.java
@@ -1,0 +1,61 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentDecisionIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.RECOMMEND,
+                        new IntentDefinition(
+                                ActionIntent.RECOMMEND,
+                                "Recommend one or more options with reasoning; support decision-making.",
+                                "User wants a recommendation: what to choose or do, with justification.",
+                                "When the goal is only to compare (COMPARE) or to propose without ranking (PROPOSE).",
+                                "RECOMMEND = recommend with reasoning; PROPOSE = suggest option; DECIDE = make the decision explicit.",
+                                "Structured recommendation with rationale.",
+                                List.of(PromptCategory.BUSINESS, PromptCategory.DESIGN, PromptCategory.DEVELOPMENT),
+                                List.of("RISK_ASSESSMENT", "PRODUCT_DESIGN", "CODE_REVIEW"),
+                                List.of("BUSINESS_CONSULTANT", "PRODUCT_DESIGNER"),
+                                "DESIGN: allowed but weaker than CREATE/EVALUATE/CRITIQUE."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.OPTIMIZE,
+                        new IntentDefinition(
+                                ActionIntent.OPTIMIZE,
+                                "Improve an existing solution against stated criteria (speed, cost, clarity).",
+                                "User has something that works and wants it improved for specific dimensions.",
+                                "When the goal is to fix broken (DIAGNOSE) or to evaluate only (EVALUATE).",
+                                "OPTIMIZE = improve against criteria; IMPROVE = general enhancement; DIAGNOSE = find cause of failure.",
+                                "Structured optimization suggestions; before/after or metrics.",
+                                List.of(PromptCategory.DEVELOPMENT, PromptCategory.BUSINESS, PromptCategory.PRODUCTIVITY),
+                                List.of("CODE_MODIFICATION", "BUSINESS_STRATEGY", "TASK_AUTOMATION"),
+                                List.of("FULL_STACK_DEVELOPER", "BUSINESS_ANALYST_BUSINESS"),
+                                "Fits technical and business optimization."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.DECIDE,
+                        new IntentDefinition(
+                                ActionIntent.DECIDE,
+                                "Make or support a binary or multi-option decision; choose among alternatives.",
+                                "User wants to decide between options or get support for a decision.",
+                                "When the goal is only to recommend (RECOMMEND) or to analyze (ANALYZE).",
+                                "DECIDE = choose; RECOMMEND = recommend with reasoning; PROPOSE = suggest option.",
+                                "Structured decision with criteria and choice.",
+                                List.of(PromptCategory.BUSINESS),
+                                List.of("RISK_ASSESSMENT", "CONTRACT_REVIEW"),
+                                List.of("BUSINESS_CONSULTANT", "BUSINESS_ANALYST_BUSINESS"),
+                                "BUSINESS: preferred for decision-support flows."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDecisionIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDecisionIntentResolutionDefaultsProvider.java
@@ -1,0 +1,30 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentDecisionIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.RECOMMEND,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.OPTIMIZE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.DECIDE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDefinitionDataSource.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDefinitionDataSource.java
@@ -1,0 +1,68 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates intent definitions/defaults provided by smaller providers.
+ * <p>
+ * IntentDictionary keeps responsibility for fail-fast completeness validation and indexing.
+ */
+final class IntentDefinitionDataSource {
+
+    record IntentDefinitionEntry(ActionIntent intent, IntentDefinition definition) {}
+
+    record IntentResolutionDefaultEntry(ActionIntent intent, IntentResolutionDefaults defaults) {}
+
+    private static final List<IntentDefinitionEntriesProvider> DEFINITIONS_PROVIDERS = List.of(
+            new IntentCreationIntentDefinitionsProvider(),
+            new IntentModificationIntentDefinitionsProvider(),
+            new IntentAnalysisIntentDefinitionsProvider(),
+            new IntentExplanationIntentDefinitionsProvider(),
+            new IntentPlanningIntentDefinitionsProvider(),
+            new IntentDecisionIntentDefinitionsProvider(),
+            new IntentResearchIntentDefinitionsProvider(),
+            new IntentExtractionIntentDefinitionsProvider()
+    );
+
+    private static final List<IntentResolutionDefaultsEntriesProvider> RESOLUTION_DEFAULTS_PROVIDERS = List.of(
+            new IntentCreationIntentResolutionDefaultsProvider(),
+            new IntentModificationIntentResolutionDefaultsProvider(),
+            new IntentAnalysisIntentResolutionDefaultsProvider(),
+            new IntentExplanationIntentResolutionDefaultsProvider(),
+            new IntentPlanningIntentResolutionDefaultsProvider(),
+            new IntentDecisionIntentResolutionDefaultsProvider(),
+            new IntentResearchIntentResolutionDefaultsProvider(),
+            new IntentExtractionIntentResolutionDefaultsProvider()
+    );
+
+    private IntentDefinitionDataSource() {}
+
+    static List<IntentDefinitionEntry> definitionsEntries() {
+        Map<ActionIntent, IntentDefinition> defs = new HashMap<>();
+        for (IntentDefinitionEntriesProvider provider : DEFINITIONS_PROVIDERS) {
+            for (IntentDefinitionEntry e : provider.entries()) {
+                defs.put(e.intent(), e.definition());
+            }
+        }
+        return defs.entrySet().stream()
+                .map(e -> new IntentDefinitionEntry(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    static List<IntentResolutionDefaultEntry> resolutionDefaultEntries() {
+        Map<ActionIntent, IntentResolutionDefaults> res = new HashMap<>();
+        for (IntentResolutionDefaultsEntriesProvider provider : RESOLUTION_DEFAULTS_PROVIDERS) {
+            for (IntentResolutionDefaultEntry e : provider.entries()) {
+                res.put(e.intent(), e.defaults());
+            }
+        }
+        return res.entrySet().stream()
+                .map(e -> new IntentResolutionDefaultEntry(e.getKey(), e.getValue()))
+                .toList();
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDefinitionEntriesProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDefinitionEntriesProvider.java
@@ -1,0 +1,14 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import java.util.List;
+
+/**
+ * Provides intent definition entries.
+ * <p>
+ * Data ownership lives in providers; {@link IntentDefinitionDataSource} only aggregates.
+ */
+interface IntentDefinitionEntriesProvider {
+
+    List<IntentDefinitionDataSource.IntentDefinitionEntry> entries();
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDictionary.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentDictionary.java
@@ -1,45 +1,41 @@
 package org.example.sharedprompts.domain.prompt.domain.semantic;
 
 import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
-import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
-import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
-import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
-import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
 
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * 공식 Intent 사전: 각 {@link ActionIntent}의 정식 의미, 사용 지침, 해석 기본값을 정의한다.
- * Intent 의미를 명시적으로 관리하여 의미적 드리프트를 줄인다.
- *
- * <p>해석 기본값(objective, output needs, response shape)은 여기에서 제공된다.
- * 프로덕션 해석 로직이 enum getter 기반 분기에 의존하지 않도록 하기 위함이다.
- * 호환성 및 intent 기본값은 enum이 아니라 dictionary/profile 레이어에서 관리한다.</p>
+ * 공식 Intent 사전: 각 {@link ActionIntent}의 정식 의미와 해석 기본값을 제공한다.
+ * <p>
+ * 실제 데이터(definition/default) 소유는 {@link IntentDefinitionDataSource}로 분리하고,
+ * 이 클래스는 “인덱싱/검증/조회”에만 집중한다.
  */
 public final class IntentDictionary {
 
     private static final Map<ActionIntent, IntentDefinition> DEFINITIONS;
 
-    /** Intent별 해석 기본값(objective, output needs, response shape). 의미 해석의 기준 소스. */
+    /**
+     * Intent별 해석 기본값(objective, output needs, response shape).
+     * 의미 해석의 기준 소스.
+     */
     private static final Map<ActionIntent, IntentResolutionDefaults> RESOLUTION_DEFAULTS;
 
     static {
         Map<ActionIntent, IntentDefinition> defs = new HashMap<>();
+        for (IntentDefinitionDataSource.IntentDefinitionEntry e : IntentDefinitionDataSource.definitionsEntries()) {
+            defs.put(e.intent(), e.definition());
+        }
+
         Map<ActionIntent, IntentResolutionDefaults> res = new HashMap<>();
-        defineCreation(defs);
-        defineModification(defs);
-        defineAnalysis(defs);
-        defineExplanation(defs);
-        definePlanning(defs);
-        defineDecision(defs);
-        defineResearch(defs);
-        defineExtraction(defs);
-        defineResolutionDefaults(res);
+        for (IntentDefinitionDataSource.IntentResolutionDefaultEntry e : IntentDefinitionDataSource.resolutionDefaultEntries()) {
+            res.put(e.intent(), e.defaults());
+        }
+
+        // fail-fast: “등록 결과” 기준으로 completeness를 강제한다.
         EnumSet<ActionIntent> allIntents = EnumSet.allOf(ActionIntent.class);
         if (!defs.keySet().containsAll(allIntents) || !res.keySet().containsAll(allIntents)) {
             EnumSet<ActionIntent> missingDefinitions = EnumSet.copyOf(allIntents);
@@ -51,55 +47,16 @@ public final class IntentDictionary {
                             + ", missingDefaults=" + missingDefaults
             );
         }
+
         DEFINITIONS = Collections.unmodifiableMap(new HashMap<>(defs));
         RESOLUTION_DEFAULTS = Collections.unmodifiableMap(new HashMap<>(res));
-    }
-
-    /**
-     * Resolution defaults owned by the dictionary; no dependency on {@link ActionIntent} enum fields.
-     * Single source of truth for intent → (objective, output needs, response shape).
-     */
-    private static void defineResolutionDefaults(Map<ActionIntent, IntentResolutionDefaults> res) {
-        putResolutionDefault(res, ActionIntent.CREATE, PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.NARRATIVE);
-        putResolutionDefault(res, ActionIntent.GENERATE, PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.NARRATIVE);
-        putResolutionDefault(res, ActionIntent.BRAINSTORM, PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.REWRITE, PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.EDIT, PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.REFINE, PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.IMPROVE, PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.ANALYZE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.EVALUATE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.COMPARE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.CRITIQUE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.DIAGNOSE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STEP_BY_STEP);
-        putResolutionDefault(res, ActionIntent.EXPLAIN, PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STEP_BY_STEP);
-        putResolutionDefault(res, ActionIntent.TEACH, PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STEP_BY_STEP);
-        putResolutionDefault(res, ActionIntent.SIMPLIFY, PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.SUMMARIZE, PromptObjective.FACTUAL, OutputNeeds.BULLET_LIST_REQUIRED, ResponseShape.CONCISE);
-        putResolutionDefault(res, ActionIntent.OUTLINE, PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.PLAN, PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STEP_BY_STEP);
-        putResolutionDefault(res, ActionIntent.STRATEGIZE, PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.PROPOSE, PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.ORGANIZE, PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.RECOMMEND, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.OPTIMIZE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.DECIDE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.INVESTIGATE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.SYNTHESIZE, PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.EXPLORE, PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.EXTRACT, PromptObjective.EXTRACTION, OutputNeeds.JSON_REQUIRED, ResponseShape.STRUCTURED);
-        putResolutionDefault(res, ActionIntent.CLASSIFY, PromptObjective.EXTRACTION, OutputNeeds.JSON_REQUIRED, ResponseShape.STRUCTURED);
-    }
-
-    private static void putResolutionDefault(Map<ActionIntent, IntentResolutionDefaults> res, ActionIntent intent, PromptObjective objective, OutputNeeds outputNeeds, ResponseShape responseShape) {
-        res.put(intent, new IntentResolutionDefaults(objective, outputNeeds, responseShape));
     }
 
     private IntentDictionary() {}
 
     /**
-     * Resolution defaults for the given intent. Use this in semantic resolution; defaults are owned by the dictionary,
-     * not by the {@link ActionIntent} enum.
+     * Resolution defaults for the given intent.
+     * semantic resolution flow에서 사용한다.
      */
     public static IntentResolutionDefaults getResolutionDefaults(ActionIntent intent) {
         IntentResolutionDefaults d = RESOLUTION_DEFAULTS.get(intent);
@@ -120,406 +77,5 @@ public final class IntentDictionary {
         }
         return d;
     }
-
-    /**
-     * Intent-only resolution defaults: objective, output needs, response shape.
-     * Used by the semantic resolution flow.
-     */
-    public record IntentResolutionDefaults(
-            PromptObjective defaultObjective,
-            OutputNeeds preferredOutputNeeds,
-            ResponseShape defaultResponseShape
-    ) {}
-
-    // ─── CREATION ─────────────────────────────────────────────────────────
-
-    private static void defineCreation(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.CREATE,
-                "Author new artifact from scratch; emphasis on original composition and ownership.",
-                "User wants to author something new (document, design, piece of content) where originality and structure matter.",
-                "When the goal is to produce output quickly from a spec (use GENERATE) or to list ideas without a single artifact (use BRAINSTORM).",
-                "CREATE = original authored composition; GENERATE = produce requested output (may be template-driven); BRAINSTORM = ideation, multiple options.",
-                "Narrative or structured new artifact; single coherent output.",
-                List.of(PromptCategory.DESIGN, PromptCategory.WRITING, PromptCategory.CONTENT_CREATION, PromptCategory.CREATIVE),
-                List.of("UI_DESIGN", "UX_DESIGN", "ARTICLE_WRITING", "CONTENT_CREATION"),
-                List.of("UI_UX_DESIGNER", "CONTENT_WRITER", "CREATIVE_DIRECTOR"),
-                "In CONTENT: prefer CREATE for long-form authored pieces; GENERATE for quick posts or templated output."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.GENERATE,
-                "Produce requested output from a description or spec; emphasis on fulfilling the request efficiently.",
-                "User wants the system to produce something (code, copy, design, list) that matches a given description or template.",
-                "When the user explicitly wants original authorship or heavy creative ownership (use CREATE).",
-                "GENERATE = produce to spec; CREATE = author from scratch with stronger creative control.",
-                "Narrative or structured output matching the request; may be more template- or spec-driven than CREATE.",
-                List.of(PromptCategory.DEVELOPMENT, PromptCategory.CONTENT_CREATION, PromptCategory.MARKETING, PromptCategory.CREATIVE),
-                List.of("CODE_GENERATION", "CONTENT_CREATION", "CONTENT_MARKETING"),
-                List.of("FULL_STACK_DEVELOPER", "CONTENT_CREATOR", "DIGITAL_MARKETER"),
-                "Default fallback for many categories when intent is unspecified."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.BRAINSTORM,
-                "Generate multiple ideas, options, or directions without committing to a single artifact.",
-                "User wants ideation, alternatives, or exploratory options rather than one final deliverable.",
-                "When the user wants a single concrete output (use CREATE or GENERATE).",
-                "BRAINSTORM = many ideas; CREATE/GENERATE = one deliverable.",
-                "Structured list or short descriptions of options; no single narrative.",
-                List.of(PromptCategory.CREATIVE, PromptCategory.BUSINESS, PromptCategory.DESIGN),
-                List.of("IDEA_GENERATION", "CREATIVE_WRITING"),
-                List.of("CREATIVE_DIRECTOR", "MARKETING_STRATEGIST"),
-                "Often pairs with CREATIVE or BUSINESS; less common in DEVELOPMENT for code."
-        ));
-    }
-
-    // ─── MODIFICATION ─────────────────────────────────────────────────────
-
-    private static void defineModification(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.REWRITE,
-                "Substantially restructure or re-express existing content; different form or voice.",
-                "User wants the same message or content in a new structure, tone, or format (e.g. formal→casual, long→short).",
-                "When only local corrections or light edits are needed (use EDIT) or polish without restructuring (use REFINE).",
-                "REWRITE = substantial restructuring/re-expression; EDIT = correctness and local fixes; REFINE = polish; IMPROVE = broader clarity/effectiveness.",
-                "Structured or narrative output in the new form; length may change.",
-                List.of(PromptCategory.WRITING, PromptCategory.CONTENT_CREATION, PromptCategory.CREATIVE),
-                List.of("EDITING", "CONTENT_REVISION", "CREATIVE_WRITING"),
-                List.of("EDITOR", "COPYWRITER", "CONTENT_STRATEGIST"),
-                "WRITING category: REWRITE and EDIT must be clearly distinguished in profiles."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.EDIT,
-                "Fix correctness, grammar, or local issues; preserve structure and voice.",
-                "User wants corrections, fixes, or small changes without changing the overall structure or tone.",
-                "When substantial restructuring or re-expression is needed (use REWRITE) or quality polish (use REFINE).",
-                "EDIT = correctness/local fixes; REWRITE = re-expression; REFINE = polish; IMPROVE = broader enhancement.",
-                "Same structure as input with corrections; minimal structural change.",
-                List.of(PromptCategory.WRITING, PromptCategory.CONTENT_CREATION),
-                List.of("EDITING", "PROOFREADING", "DOC_UPDATE"),
-                List.of("EDITOR", "CONTENT_WRITER"),
-                "Preferred for copy-editing and proofreading flows."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.REFINE,
-                "Polish and elevate quality of existing content; improve clarity and style without major restructuring.",
-                "User wants to improve flow, word choice, and quality while keeping the same message and structure.",
-                "When structural changes are needed (use REWRITE) or only typo/grammar fixes (use EDIT).",
-                "REFINE = polish and quality; EDIT = correctness; REWRITE = restructure; IMPROVE = broader effectiveness.",
-                "Same structure, higher quality; more polished language.",
-                List.of(PromptCategory.WRITING, PromptCategory.DEVELOPMENT),
-                List.of("EDITING", "CODE_MODIFICATION"),
-                List.of("EDITOR", "COPYWRITER"),
-                "DEVELOPMENT: REFINE for code quality and readability improvements."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.IMPROVE,
-                "Broader enhancement of clarity, effectiveness, or impact; may include structure and content.",
-                "User wants overall improvement (readability, impact, clarity) without specifying exact type of change.",
-                "When the need is narrowly correctness (EDIT), polish only (REFINE), or full re-expression (REWRITE).",
-                "IMPROVE = broad enhancement; REFINE = polish; EDIT = fixes; REWRITE = re-express.",
-                "Improved version; may include structural tweaks and content adjustments.",
-                List.of(PromptCategory.WRITING, PromptCategory.DEVELOPMENT, PromptCategory.CONTENT_CREATION),
-                List.of("EDITING", "CODE_MODIFICATION", "CONTENT_OPTIMIZATION"),
-                List.of("EDITOR", "CONTENT_WRITER", "BACKEND_DEVELOPER"),
-                "General-purpose improvement intent across writing and development."
-        ));
-    }
-
-    // ─── ANALYSIS ──────────────────────────────────────────────────────────
-
-    private static void defineAnalysis(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.ANALYZE,
-                "Break down a subject into components, patterns, or factors; systematic examination.",
-                "User wants understanding of parts, causes, or patterns in data, text, or a system.",
-                "When the goal is judgment of merit (use EVALUATE), comparison (use COMPARE), or fault-finding (use DIAGNOSE).",
-                "ANALYZE = break down and examine; EVALUATE = judge merit; CRITIQUE = judge with standards; DIAGNOSE = find cause of problem.",
-                "Structured analysis; components, factors, or patterns.",
-                List.of(PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS, PromptCategory.RESEARCH, PromptCategory.BUSINESS),
-                List.of("DATA_ANALYSIS", "LITERATURE_REVIEW", "ROOT_CAUSE_ANALYSIS"),
-                List.of("GENERAL_CONSULTANT", "RESEARCHER", "BUSINESS_ANALYST_BUSINESS"),
-                "Core intent for ANALYSIS and RESEARCH categories."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.EVALUATE,
-                "Judge merit, quality, or suitability against criteria or goals.",
-                "User wants an assessment of how good, suitable, or effective something is.",
-                "When the goal is only to break down or describe (use ANALYZE) or to compare two things (use COMPARE).",
-                "EVALUATE = judge merit; ANALYZE = examine components; CRITIQUE = evaluate against explicit standards; COMPARE = compare alternatives.",
-                "Structured evaluation with criteria and judgment.",
-                List.of(PromptCategory.DESIGN, PromptCategory.DEVELOPMENT, PromptCategory.RESEARCH),
-                List.of("CODE_REVIEW", "UX_DESIGN", "COMPARATIVE_ANALYSIS"),
-                List.of("UI_UX_DESIGNER", "PRODUCT_DESIGNER", "RESEARCHER"),
-                "DESIGN: preferred for design review and critique flows."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.COMPARE,
-                "Place two or more items side by side; highlight similarities and differences.",
-                "User wants a direct comparison of options, versions, or alternatives.",
-                "When the goal is single-item analysis (ANALYZE) or a merit judgment (EVALUATE).",
-                "COMPARE = side-by-side comparison; ANALYZE = single subject breakdown; EVALUATE = merit judgment.",
-                "Structured comparison; pros/cons or dimension-based.",
-                List.of(PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS, PromptCategory.BUSINESS, PromptCategory.RESEARCH),
-                List.of("COMPARATIVE_ANALYSIS", "DATA_ANALYSIS"),
-                List.of("BUSINESS_ANALYST_BUSINESS", "RESEARCHER"),
-                "Fits ANALYSIS and RESEARCH; often used with DECIDE or RECOMMEND."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.CRITIQUE,
-                "Judge against explicit standards or criteria; constructive criticism.",
-                "User wants feedback that evaluates against defined standards (e.g. design principles, style guide).",
-                "When the goal is neutral analysis (ANALYZE) or open-ended evaluation without standards (EVALUATE).",
-                "CRITIQUE = judge against standards; EVALUATE = general merit; ANALYZE = break down without judgment.",
-                "Structured critique with criteria and suggestions.",
-                List.of(PromptCategory.DESIGN, PromptCategory.WRITING, PromptCategory.RESEARCH),
-                List.of("UI_DESIGN", "UX_DESIGN", "EDITING"),
-                List.of("UI_UX_DESIGNER", "PRODUCT_DESIGNER", "EDITOR"),
-                "DESIGN: preferred for design review; DIAGNOSE only in narrow debug/critique contexts."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.DIAGNOSE,
-                "Identify cause of a problem or failure; root-cause or fault-finding.",
-                "User has a problem (bug, failure, issue) and wants to understand why it occurs.",
-                "When the goal is general analysis (ANALYZE), merit evaluation (EVALUATE), or design critique (CRITIQUE).",
-                "DIAGNOSE = find cause of problem; ANALYZE = general breakdown; CRITIQUE = judge against standards.",
-                "Step-by-step or structured diagnosis; cause-and-effect.",
-                List.of(PromptCategory.DEVELOPMENT, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
-                List.of("DEBUGGING", "CODE_ANALYSIS", "ROOT_CAUSE_ANALYSIS"),
-                List.of("BACKEND_DEVELOPER", "FRONTEND_DEVELOPER"),
-                "DESIGN: discouraged unless critique/debug context is explicit (e.g. usability bug)."
-        ));
-    }
-
-    // ─── EXPLANATION ───────────────────────────────────────────────────────
-
-    private static void defineExplanation(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.EXPLAIN,
-                "Make a topic or process understandable; clarify how or why.",
-                "User wants to understand something (concept, process, system) in a clear way.",
-                "When the goal is to teach a curriculum (use TEACH), shorten (use SIMPLIFY), or condense (use SUMMARIZE).",
-                "EXPLAIN = clarify how/why; TEACH = instructional sequence; SIMPLIFY = reduce complexity; SUMMARIZE = condense.",
-                "Step-by-step or structured explanation; pedagogical tone optional.",
-                List.of(PromptCategory.EDUCATION, PromptCategory.DEVELOPMENT, PromptCategory.RESEARCH),
-                List.of("DOCUMENTATION", "TEACHING_METHOD", "RESEARCH_DESIGN"),
-                List.of("EDUCATOR", "RESEARCH_METHODOLOGIST", "FULL_STACK_DEVELOPER"),
-                "Core intent for EDUCATION and STUDY."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.TEACH,
-                "Instruct in a learning sequence; curriculum or lesson oriented.",
-                "User wants to learn a topic in a structured, pedagogical way.",
-                "When the goal is a one-off explanation (EXPLAIN) or simplification of existing content (SIMPLIFY).",
-                "TEACH = instructional sequence; EXPLAIN = single explanation; SIMPLIFY = reduce complexity of given content.",
-                "Step-by-step lesson; may include examples and exercises.",
-                List.of(PromptCategory.EDUCATION),
-                List.of("TEACHING_METHOD", "LESSON_PLANNING", "EXAM_PREPARATION"),
-                List.of("EDUCATOR", "CURRICULUM_DESIGNER", "TUTOR"),
-                "Prefer EXPLAIN for one-off clarification; TEACH for learning paths."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.SIMPLIFY,
-                "Reduce complexity of given content or concept; make more accessible.",
-                "User has complex material and wants it made easier to understand.",
-                "When the goal is to condense length (use SUMMARIZE) or to explain from scratch (use EXPLAIN).",
-                "SIMPLIFY = reduce complexity; SUMMARIZE = shorten; EXPLAIN = clarify how/why.",
-                "Simpler version of the same content; structure may be reorganized.",
-                List.of(PromptCategory.EDUCATION, PromptCategory.WRITING),
-                List.of("MATERIAL_CREATION", "KNOWLEDGE_ORGANIZATION"),
-                List.of("EDUCATOR", "TECHNICAL_WRITER"),
-                "Often used for technical or academic content simplification."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.SUMMARIZE,
-                "Condense content to key points; preserve meaning, reduce length.",
-                "User wants a shorter version that captures the main points.",
-                "When the goal is to simplify complexity (SIMPLIFY) or to explain (EXPLAIN).",
-                "SUMMARIZE = condense; SIMPLIFY = reduce complexity; OUTLINE = structure only.",
-                "Bullet list or concise narrative; minimal new content.",
-                List.of(PromptCategory.RESEARCH, PromptCategory.WRITING, PromptCategory.EDUCATION, PromptCategory.BUSINESS),
-                List.of("LITERATURE_REVIEW", "NOTE_TAKING", "ARTICLE_WRITING"),
-                List.of("RESEARCHER", "EDITOR", "STUDY_COACH"),
-                "Output often bullet-list; OutputNeeds.BULLET_LIST_REQUIRED in intent."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.OUTLINE,
-                "Produce structure or skeleton of content; headings and order without full body.",
-                "User wants a plan or skeleton (headings, sections) before or instead of full content.",
-                "When the goal is full content (CREATE/GENERATE) or a summary of existing content (SUMMARIZE).",
-                "OUTLINE = structure only; PLAN = plan of work; SUMMARIZE = condense existing.",
-                "Structured list of sections or steps; no full narrative.",
-                List.of(PromptCategory.WRITING, PromptCategory.CONTENT_CREATION, PromptCategory.BUSINESS),
-                List.of("CONTENT_PLANNING", "ARTICLE_WRITING"),
-                List.of("CONTENT_WRITER", "PROJECT_MANAGER"),
-                "WRITING: preferred for structuring before writing."
-        ));
-    }
-
-    // ─── PLANNING ─────────────────────────────────────────────────────────
-
-    private static void definePlanning(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.PLAN,
-                "Produce a sequence of steps or phases to achieve a goal.",
-                "User wants a plan: what to do, in what order, to reach an outcome.",
-                "When the goal is strategy (STRATEGIZE), a proposal (PROPOSE), or organization of existing items (ORGANIZE).",
-                "PLAN = steps/phases; STRATEGIZE = high-level approach; PROPOSE = suggest option; ORGANIZE = arrange existing.",
-                "Step-by-step or phased plan.",
-                List.of(PromptCategory.PRODUCTIVITY, PromptCategory.BUSINESS, PromptCategory.EDUCATION, PromptCategory.DEVELOPMENT),
-                List.of("SCHEDULE_PLANNING", "BUSINESS_PLAN_DEVELOPMENT", "LESSON_PLANNING", "ARCHITECTURE_DESIGN"),
-                List.of("PRODUCTIVITY_EXPERT", "PROJECT_MANAGER", "CURRICULUM_DESIGNER"),
-                "Fallback for PRODUCTIVITY when intent missing."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.STRATEGIZE,
-                "Define high-level approach, direction, or strategy; not a detailed step list.",
-                "User wants strategic guidance: direction, principles, or approach rather than a task list.",
-                "When the goal is a concrete plan (PLAN) or a specific proposal (PROPOSE).",
-                "STRATEGIZE = high-level approach; PLAN = step sequence; PROPOSE = concrete suggestion.",
-                "Structured strategy; principles and priorities.",
-                List.of(PromptCategory.BUSINESS, PromptCategory.MARKETING),
-                List.of("BUSINESS_STRATEGY", "MARKETING_STRATEGY"),
-                List.of("BUSINESS_CONSULTANT", "MARKETING_STRATEGIST"),
-                "Often used with BUSINESS and MARKETING."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.PROPOSE,
-                "Suggest a concrete option, solution, or recommendation for a decision.",
-                "User wants a specific proposal: what to do or choose, with rationale.",
-                "When the goal is open strategy (STRATEGIZE) or a neutral plan (PLAN).",
-                "PROPOSE = suggest option; RECOMMEND = recommend with reasoning; PLAN = steps.",
-                "Structured proposal with rationale.",
-                List.of(PromptCategory.BUSINESS, PromptCategory.DEVELOPMENT),
-                List.of("PROPOSAL_WRITING", "SYSTEM_DESIGN", "BUSINESS_PLAN_DEVELOPMENT"),
-                List.of("BUSINESS_CONSULTANT", "CLOUD_ARCHITECT"),
-                "BUSINESS: preferred for proposals and option presentation."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.ORGANIZE,
-                "Arrange existing items into structure, order, or categories.",
-                "User has existing items (ideas, tasks, content) and wants them ordered or grouped.",
-                "When the goal is to create new content (CREATE/GENERATE) or to plan from scratch (PLAN).",
-                "ORGANIZE = arrange existing; PLAN = define steps; OUTLINE = structure for content.",
-                "Structured list or taxonomy.",
-                List.of(PromptCategory.PRODUCTIVITY, PromptCategory.EDUCATION, PromptCategory.CONTENT_CREATION),
-                List.of("TASK_AUTOMATION", "KNOWLEDGE_ORGANIZATION", "CONTENT_PLANNING"),
-                List.of("PRODUCTIVITY_EXPERT", "STUDY_COACH"),
-                "Less common than PLAN; fits productivity and study."
-        ));
-    }
-
-    // ─── DECISION ────────────────────────────────────────────────────────
-
-    private static void defineDecision(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.RECOMMEND,
-                "Recommend one or more options with reasoning; support decision-making.",
-                "User wants a recommendation: what to choose or do, with justification.",
-                "When the goal is only to compare (COMPARE) or to propose without ranking (PROPOSE).",
-                "RECOMMEND = recommend with reasoning; PROPOSE = suggest option; DECIDE = make the decision explicit.",
-                "Structured recommendation with rationale.",
-                List.of(PromptCategory.BUSINESS, PromptCategory.DESIGN, PromptCategory.DEVELOPMENT),
-                List.of("RISK_ASSESSMENT", "PRODUCT_DESIGN", "CODE_REVIEW"),
-                List.of("BUSINESS_CONSULTANT", "PRODUCT_DESIGNER"),
-                "DESIGN: allowed but weaker than CREATE/EVALUATE/CRITIQUE."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.OPTIMIZE,
-                "Improve an existing solution against stated criteria (speed, cost, clarity).",
-                "User has something that works and wants it improved for specific dimensions.",
-                "When the goal is to fix broken (DIAGNOSE) or to evaluate only (EVALUATE).",
-                "OPTIMIZE = improve against criteria; IMPROVE = general enhancement; DIAGNOSE = find cause of failure.",
-                "Structured optimization suggestions; before/after or metrics.",
-                List.of(PromptCategory.DEVELOPMENT, PromptCategory.BUSINESS, PromptCategory.PRODUCTIVITY),
-                List.of("CODE_MODIFICATION", "BUSINESS_STRATEGY", "TASK_AUTOMATION"),
-                List.of("FULL_STACK_DEVELOPER", "BUSINESS_ANALYST_BUSINESS"),
-                "Fits technical and business optimization."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.DECIDE,
-                "Make or support a binary or multi-option decision; choose among alternatives.",
-                "User wants to decide between options or get support for a decision.",
-                "When the goal is only to recommend (RECOMMEND) or to analyze (ANALYZE).",
-                "DECIDE = choose; RECOMMEND = recommend with reasoning; PROPOSE = suggest option.",
-                "Structured decision with criteria and choice.",
-                List.of(PromptCategory.BUSINESS),
-                List.of("RISK_ASSESSMENT", "CONTRACT_REVIEW"),
-                List.of("BUSINESS_CONSULTANT", "BUSINESS_ANALYST_BUSINESS"),
-                "BUSINESS: preferred for decision-support flows."
-        ));
-    }
-
-    // ─── RESEARCH ─────────────────────────────────────────────────────────
-
-    private static void defineResearch(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.INVESTIGATE,
-                "Systematically look into a question or topic; gather and examine evidence.",
-                "User wants to investigate a question: what is known, what are sources, what are findings.",
-                "When the goal is to synthesize into one view (SYNTHESIZE) or to explore freely (EXPLORE).",
-                "INVESTIGATE = systematic inquiry; SYNTHESIZE = combine into one view; EXPLORE = open exploration.",
-                "Structured findings; may include sources and caveats.",
-                List.of(PromptCategory.RESEARCH, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
-                List.of("LITERATURE_REVIEW", "DATA_INTERPRETATION", "RESEARCH_DESIGN"),
-                List.of("RESEARCHER", "RESEARCH_METHODOLOGIST"),
-                "RESEARCH: preferred for literature and evidence-based inquiry."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.SYNTHESIZE,
-                "Combine multiple sources or views into a single coherent position or summary.",
-                "User has multiple inputs (papers, opinions, data) and wants them synthesized.",
-                "When the goal is to investigate (INVESTIGATE) or to explore (EXPLORE) without synthesis.",
-                "SYNTHESIZE = combine into one; INVESTIGATE = look into; EXPLORE = open exploration.",
-                "Structured synthesis; integrated view with sources.",
-                List.of(PromptCategory.RESEARCH, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
-                List.of("LITERATURE_REVIEW", "STATISTICAL_MODELING", "DATA_INTERPRETATION"),
-                List.of("RESEARCHER", "ACADEMIC_WRITER"),
-                "RESEARCH: preferred for literature review and evidence synthesis; PERSUASIVE tone discouraged unless explicit."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.EXPLORE,
-                "Open-ended exploration of ideas, options, or possibilities; less structured than investigate.",
-                "User wants to explore a space of ideas or options without a fixed question.",
-                "When the goal is systematic investigation (INVESTIGATE) or synthesis (SYNTHESIZE).",
-                "EXPLORE = open exploration; INVESTIGATE = systematic; SYNTHESIZE = combine into one.",
-                "Structured exploration; multiple angles or options.",
-                List.of(PromptCategory.RESEARCH, PromptCategory.CREATIVE),
-                List.of("IDEA_GENERATION", "LITERATURE_REVIEW"),
-                List.of("RESEARCHER", "CREATIVE_DIRECTOR"),
-                "Less formal than INVESTIGATE; fits creative and research."
-        ));
-    }
-
-    // ─── EXTRACTION ────────────────────────────────────────────────────────
-
-    private static void defineExtraction(Map<ActionIntent, IntentDefinition> defs) {
-        put(defs, new IntentDefinition(
-                ActionIntent.EXTRACT,
-                "Pull structured data or entities from unstructured input; output in specified schema (e.g. JSON).",
-                "User wants to extract specific fields, entities, or facts from text or content.",
-                "When the goal is to classify into categories only (use CLASSIFY) or to summarize (use SUMMARIZE).",
-                "EXTRACT = structured extraction to schema; CLASSIFY = assign categories/labels.",
-                "Structured output (e.g. JSON); schema-driven.",
-                List.of(PromptCategory.EXTRACTION, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS, PromptCategory.RESEARCH),
-                List.of("DATA_ANALYSIS"),
-                List.of("GENERAL_CONSULTANT"),
-                "EXTRACTION request_mode forces intent=EXTRACT; category=EXTRACTION."
-        ));
-        put(defs, new IntentDefinition(
-                ActionIntent.CLASSIFY,
-                "Assign category, label, or tag to input; classification or categorization.",
-                "User wants to classify content into predefined categories or labels.",
-                "When the goal is to extract multiple fields (use EXTRACT) or to summarize (use SUMMARIZE).",
-                "CLASSIFY = assign category; EXTRACT = extract fields to schema.",
-                "Structured labels or categories.",
-                List.of(PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
-                List.of("DATA_ANALYSIS"),
-                List.of("GENERAL_CONSULTANT"),
-                "Fits ANALYSIS and extraction-style flows."
-        ));
-    }
-
-    private static void put(Map<ActionIntent, IntentDefinition> map, IntentDefinition def) {
-        map.put(def.intent(), def);
-    }
 }
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExplanationIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExplanationIntentDefinitionsProvider.java
@@ -1,0 +1,91 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentExplanationIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.EXPLAIN,
+                        new IntentDefinition(
+                                ActionIntent.EXPLAIN,
+                                "Make a topic or process understandable; clarify how or why.",
+                                "User wants to understand something (concept, process, system) in a clear way.",
+                                "When the goal is to teach a curriculum (use TEACH), shorten (use SIMPLIFY), or condense (use SUMMARIZE).",
+                                "EXPLAIN = clarify how/why; TEACH = instructional sequence; SIMPLIFY = reduce complexity; SUMMARIZE = condense.",
+                                "Step-by-step or structured explanation; pedagogical tone optional.",
+                                List.of(PromptCategory.EDUCATION, PromptCategory.DEVELOPMENT, PromptCategory.RESEARCH),
+                                List.of("DOCUMENTATION", "TEACHING_METHOD", "RESEARCH_DESIGN"),
+                                List.of("EDUCATOR", "RESEARCH_METHODOLOGIST", "FULL_STACK_DEVELOPER"),
+                                "Core intent for EDUCATION and STUDY."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.TEACH,
+                        new IntentDefinition(
+                                ActionIntent.TEACH,
+                                "Instruct in a learning sequence; curriculum or lesson oriented.",
+                                "User wants to learn a topic in a structured, pedagogical way.",
+                                "When the goal is a one-off explanation (EXPLAIN) or simplification of existing content (SIMPLIFY).",
+                                "TEACH = instructional sequence; EXPLAIN = single explanation; SIMPLIFY = reduce complexity of given content.",
+                                "Step-by-step lesson; may include examples and exercises.",
+                                List.of(PromptCategory.EDUCATION),
+                                List.of("TEACHING_METHOD", "LESSON_PLANNING", "EXAM_PREPARATION"),
+                                List.of("EDUCATOR", "CURRICULUM_DESIGNER", "TUTOR"),
+                                "Prefer EXPLAIN for one-off clarification; TEACH for learning paths."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.SIMPLIFY,
+                        new IntentDefinition(
+                                ActionIntent.SIMPLIFY,
+                                "Reduce complexity of given content or concept; make more accessible.",
+                                "User has complex material and wants it made easier to understand.",
+                                "When the goal is to condense length (use SUMMARIZE) or to explain from scratch (use EXPLAIN).",
+                                "SIMPLIFY = reduce complexity; SUMMARIZE = shorten; EXPLAIN = clarify how/why.",
+                                "Simpler version of the same content; structure may be reorganized.",
+                                List.of(PromptCategory.EDUCATION, PromptCategory.WRITING),
+                                List.of("MATERIAL_CREATION", "KNOWLEDGE_ORGANIZATION"),
+                                List.of("EDUCATOR", "TECHNICAL_WRITER"),
+                                "Often used for technical or academic content simplification."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.SUMMARIZE,
+                        new IntentDefinition(
+                                ActionIntent.SUMMARIZE,
+                                "Condense content to key points; preserve meaning, reduce length.",
+                                "User wants a shorter version that captures the main points.",
+                                "When the goal is to simplify complexity (SIMPLIFY) or to explain (EXPLAIN).",
+                                "SUMMARIZE = condense; SIMPLIFY = reduce complexity; OUTLINE = structure only.",
+                                "Bullet list or concise narrative; minimal new content.",
+                                List.of(PromptCategory.RESEARCH, PromptCategory.WRITING, PromptCategory.EDUCATION, PromptCategory.BUSINESS),
+                                List.of("LITERATURE_REVIEW", "NOTE_TAKING", "ARTICLE_WRITING"),
+                                List.of("RESEARCHER", "EDITOR", "STUDY_COACH"),
+                                "Output often bullet-list; OutputNeeds.BULLET_LIST_REQUIRED in intent."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.OUTLINE,
+                        new IntentDefinition(
+                                ActionIntent.OUTLINE,
+                                "Produce structure or skeleton of content; headings and order without full body.",
+                                "User wants a plan or skeleton (headings, sections) before or instead of full content.",
+                                "When the goal is full content (CREATE/GENERATE) or a summary of existing content (SUMMARIZE).",
+                                "OUTLINE = structure only; PLAN = plan of work; SUMMARIZE = condense existing.",
+                                "Structured list of sections or steps; no full narrative.",
+                                List.of(PromptCategory.WRITING, PromptCategory.CONTENT_CREATION, PromptCategory.BUSINESS),
+                                List.of("CONTENT_PLANNING", "ARTICLE_WRITING"),
+                                List.of("CONTENT_WRITER", "PROJECT_MANAGER"),
+                                "WRITING: preferred for structuring before writing."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExplanationIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExplanationIntentResolutionDefaultsProvider.java
@@ -1,0 +1,38 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentExplanationIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.EXPLAIN,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STEP_BY_STEP)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.TEACH,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STEP_BY_STEP)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.SIMPLIFY,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.SUMMARIZE,
+                        new IntentResolutionDefaults(PromptObjective.FACTUAL, OutputNeeds.BULLET_LIST_REQUIRED, ResponseShape.CONCISE)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.OUTLINE,
+                        new IntentResolutionDefaults(PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExtractionIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExtractionIntentDefinitionsProvider.java
@@ -1,0 +1,46 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentExtractionIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.EXTRACT,
+                        new IntentDefinition(
+                                ActionIntent.EXTRACT,
+                                "Pull structured data or entities from unstructured input; output in specified schema (e.g. JSON).",
+                                "User wants to extract specific fields, entities, or facts from text or content.",
+                                "When the goal is to classify into categories only (use CLASSIFY) or to summarize (use SUMMARIZE).",
+                                "EXTRACT = structured extraction to schema; CLASSIFY = assign categories/labels.",
+                                "Structured output (e.g. JSON); schema-driven.",
+                                List.of(PromptCategory.EXTRACTION, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS, PromptCategory.RESEARCH),
+                                List.of("DATA_ANALYSIS"),
+                                List.of("GENERAL_CONSULTANT"),
+                                "EXTRACTION request_mode forces intent=EXTRACT; category=EXTRACTION."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.CLASSIFY,
+                        new IntentDefinition(
+                                ActionIntent.CLASSIFY,
+                                "Assign category, label, or tag to input; classification or categorization.",
+                                "User wants to classify content into predefined categories or labels.",
+                                "When the goal is to extract multiple fields (use EXTRACT) or to summarize (use SUMMARIZE).",
+                                "CLASSIFY = assign category; EXTRACT = extract fields to schema.",
+                                "Structured labels or categories.",
+                                List.of(PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
+                                List.of("DATA_ANALYSIS"),
+                                List.of("GENERAL_CONSULTANT"),
+                                "Fits ANALYSIS and extraction-style flows."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExtractionIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentExtractionIntentResolutionDefaultsProvider.java
@@ -1,0 +1,26 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentExtractionIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.EXTRACT,
+                        new IntentResolutionDefaults(PromptObjective.EXTRACTION, OutputNeeds.JSON_REQUIRED, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.CLASSIFY,
+                        new IntentResolutionDefaults(PromptObjective.EXTRACTION, OutputNeeds.JSON_REQUIRED, ResponseShape.STRUCTURED)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentModificationIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentModificationIntentDefinitionsProvider.java
@@ -1,0 +1,76 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentModificationIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.REWRITE,
+                        new IntentDefinition(
+                                ActionIntent.REWRITE,
+                                "Substantially restructure or re-express existing content; different form or voice.",
+                                "User wants the same message or content in a new structure, tone, or format (e.g. formal→casual, long→short).",
+                                "When only local corrections or light edits are needed (use EDIT) or polish without restructuring (use REFINE).",
+                                "REWRITE = substantial restructuring/re-expression; EDIT = correctness and local fixes; REFINE = polish; IMPROVE = broader clarity/effectiveness.",
+                                "Structured or narrative output in the new form; length may change.",
+                                List.of(PromptCategory.WRITING, PromptCategory.CONTENT_CREATION, PromptCategory.CREATIVE),
+                                List.of("EDITING", "CONTENT_REVISION", "CREATIVE_WRITING"),
+                                List.of("EDITOR", "COPYWRITER", "CONTENT_STRATEGIST"),
+                                "WRITING category: REWRITE and EDIT must be clearly distinguished in profiles."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.EDIT,
+                        new IntentDefinition(
+                                ActionIntent.EDIT,
+                                "Fix correctness, grammar, or local issues; preserve structure and voice.",
+                                "User wants corrections, fixes, or small changes without changing the overall structure or tone.",
+                                "When substantial restructuring or re-expression is needed (use REWRITE) or quality polish (use REFINE).",
+                                "EDIT = correctness/local fixes; REWRITE = re-expression; REFINE = polish; IMPROVE = broader enhancement.",
+                                "Same structure as input with corrections; minimal structural change.",
+                                List.of(PromptCategory.WRITING, PromptCategory.CONTENT_CREATION),
+                                List.of("EDITING", "PROOFREADING", "DOC_UPDATE"),
+                                List.of("EDITOR", "CONTENT_WRITER"),
+                                "Preferred for copy-editing and proofreading flows."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.REFINE,
+                        new IntentDefinition(
+                                ActionIntent.REFINE,
+                                "Polish and elevate quality of existing content; improve clarity and style without major restructuring.",
+                                "User wants to improve flow, word choice, and quality while keeping the same message and structure.",
+                                "When structural changes are needed (use REWRITE) or only typo/grammar fixes (use EDIT).",
+                                "REFINE = polish and quality; EDIT = correctness; REWRITE = restructure; IMPROVE = broader effectiveness.",
+                                "Same structure, higher quality; more polished language.",
+                                List.of(PromptCategory.WRITING, PromptCategory.DEVELOPMENT),
+                                List.of("EDITING", "CODE_MODIFICATION"),
+                                List.of("EDITOR", "COPYWRITER"),
+                                "DEVELOPMENT: REFINE for code quality and readability improvements."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.IMPROVE,
+                        new IntentDefinition(
+                                ActionIntent.IMPROVE,
+                                "Broader enhancement of clarity, effectiveness, or impact; may include structure and content.",
+                                "User wants overall improvement (readability, impact, clarity) without specifying exact type of change.",
+                                "When the need is narrowly correctness (EDIT), polish only (REFINE), or full re-expression (REWRITE).",
+                                "IMPROVE = broad enhancement; REFINE = polish; EDIT = fixes; REWRITE = re-express.",
+                                "Improved version; may include structural tweaks and content adjustments.",
+                                List.of(PromptCategory.WRITING, PromptCategory.DEVELOPMENT, PromptCategory.CONTENT_CREATION),
+                                List.of("EDITING", "CODE_MODIFICATION", "CONTENT_OPTIMIZATION"),
+                                List.of("EDITOR", "CONTENT_WRITER", "BACKEND_DEVELOPER"),
+                                "General-purpose improvement intent across writing and development."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentModificationIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentModificationIntentResolutionDefaultsProvider.java
@@ -1,0 +1,34 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentModificationIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.REWRITE,
+                        new IntentResolutionDefaults(PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.EDIT,
+                        new IntentResolutionDefaults(PromptObjective.CREATIVE, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.REFINE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.IMPROVE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentPlanningIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentPlanningIntentDefinitionsProvider.java
@@ -1,0 +1,76 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentPlanningIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.PLAN,
+                        new IntentDefinition(
+                                ActionIntent.PLAN,
+                                "Produce a sequence of steps or phases to achieve a goal.",
+                                "User wants a plan: what to do, in what order, to reach an outcome.",
+                                "When the goal is strategy (STRATEGIZE), a proposal (PROPOSE), or organization of existing items (ORGANIZE).",
+                                "PLAN = steps/phases; STRATEGIZE = high-level approach; PROPOSE = suggest option; ORGANIZE = arrange existing.",
+                                "Step-by-step or phased plan.",
+                                List.of(PromptCategory.PRODUCTIVITY, PromptCategory.BUSINESS, PromptCategory.EDUCATION, PromptCategory.DEVELOPMENT),
+                                List.of("SCHEDULE_PLANNING", "BUSINESS_PLAN_DEVELOPMENT", "LESSON_PLANNING", "ARCHITECTURE_DESIGN"),
+                                List.of("PRODUCTIVITY_EXPERT", "PROJECT_MANAGER", "CURRICULUM_DESIGNER"),
+                                "Fallback for PRODUCTIVITY when intent missing."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.STRATEGIZE,
+                        new IntentDefinition(
+                                ActionIntent.STRATEGIZE,
+                                "Define high-level approach, direction, or strategy; not a detailed step list.",
+                                "User wants strategic guidance: direction, principles, or approach rather than a task list.",
+                                "When the goal is a concrete plan (PLAN) or a specific proposal (PROPOSE).",
+                                "STRATEGIZE = high-level approach; PLAN = step sequence; PROPOSE = concrete suggestion.",
+                                "Structured strategy; principles and priorities.",
+                                List.of(PromptCategory.BUSINESS, PromptCategory.MARKETING),
+                                List.of("BUSINESS_STRATEGY", "MARKETING_STRATEGY"),
+                                List.of("BUSINESS_CONSULTANT", "MARKETING_STRATEGIST"),
+                                "Often used with BUSINESS and MARKETING."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.PROPOSE,
+                        new IntentDefinition(
+                                ActionIntent.PROPOSE,
+                                "Suggest a concrete option, solution, or recommendation for a decision.",
+                                "User wants a specific proposal: what to do or choose, with rationale.",
+                                "When the goal is open strategy (STRATEGIZE) or a neutral plan (PLAN).",
+                                "PROPOSE = suggest option; RECOMMEND = recommend with reasoning; PLAN = steps.",
+                                "Structured proposal with rationale.",
+                                List.of(PromptCategory.BUSINESS, PromptCategory.DEVELOPMENT),
+                                List.of("PROPOSAL_WRITING", "SYSTEM_DESIGN", "BUSINESS_PLAN_DEVELOPMENT"),
+                                List.of("BUSINESS_CONSULTANT", "CLOUD_ARCHITECT"),
+                                "BUSINESS: preferred for proposals and option presentation."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.ORGANIZE,
+                        new IntentDefinition(
+                                ActionIntent.ORGANIZE,
+                                "Arrange existing items into structure, order, or categories.",
+                                "User has existing items (ideas, tasks, content) and wants them ordered or grouped.",
+                                "When the goal is to create new content (CREATE/GENERATE) or to plan from scratch (PLAN).",
+                                "ORGANIZE = arrange existing; PLAN = define steps; OUTLINE = structure for content.",
+                                "Structured list or taxonomy.",
+                                List.of(PromptCategory.PRODUCTIVITY, PromptCategory.EDUCATION, PromptCategory.CONTENT_CREATION),
+                                List.of("TASK_AUTOMATION", "KNOWLEDGE_ORGANIZATION", "CONTENT_PLANNING"),
+                                List.of("PRODUCTIVITY_EXPERT", "STUDY_COACH"),
+                                "Less common than PLAN; fits productivity and study."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentPlanningIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentPlanningIntentResolutionDefaultsProvider.java
@@ -1,0 +1,34 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentPlanningIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.PLAN,
+                        new IntentResolutionDefaults(PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STEP_BY_STEP)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.STRATEGIZE,
+                        new IntentResolutionDefaults(PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.PROPOSE,
+                        new IntentResolutionDefaults(PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.ORGANIZE,
+                        new IntentResolutionDefaults(PromptObjective.PLANNING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResearchIntentDefinitionsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResearchIntentDefinitionsProvider.java
@@ -1,0 +1,61 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
+
+import java.util.List;
+
+final class IntentResearchIntentDefinitionsProvider implements IntentDefinitionEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentDefinitionEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.INVESTIGATE,
+                        new IntentDefinition(
+                                ActionIntent.INVESTIGATE,
+                                "Systematically look into a question or topic; gather and examine evidence.",
+                                "User wants to investigate a question: what is known, what are sources, what are findings.",
+                                "When the goal is to synthesize into one view (SYNTHESIZE) or to explore freely (EXPLORE).",
+                                "INVESTIGATE = systematic inquiry; SYNTHESIZE = combine into one view; EXPLORE = open exploration.",
+                                "Structured findings; may include sources and caveats.",
+                                List.of(PromptCategory.RESEARCH, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
+                                List.of("LITERATURE_REVIEW", "DATA_INTERPRETATION", "RESEARCH_DESIGN"),
+                                List.of("RESEARCHER", "RESEARCH_METHODOLOGIST"),
+                                "RESEARCH: preferred for literature and evidence-based inquiry."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.SYNTHESIZE,
+                        new IntentDefinition(
+                                ActionIntent.SYNTHESIZE,
+                                "Combine multiple sources or views into a single coherent position or summary.",
+                                "User has multiple inputs (papers, opinions, data) and wants them synthesized.",
+                                "When the goal is to investigate (INVESTIGATE) or to explore (EXPLORE) without synthesis.",
+                                "SYNTHESIZE = combine into one; INVESTIGATE = look into; EXPLORE = open exploration.",
+                                "Structured synthesis; integrated view with sources.",
+                                List.of(PromptCategory.RESEARCH, PromptCategory.ANALYSIS, PromptCategory.DATA_ANALYSIS),
+                                List.of("LITERATURE_REVIEW", "STATISTICAL_MODELING", "DATA_INTERPRETATION"),
+                                List.of("RESEARCHER", "ACADEMIC_WRITER"),
+                                "RESEARCH: preferred for literature review and evidence synthesis; PERSUASIVE tone discouraged unless explicit."
+                        )
+                ),
+                new IntentDefinitionDataSource.IntentDefinitionEntry(
+                        ActionIntent.EXPLORE,
+                        new IntentDefinition(
+                                ActionIntent.EXPLORE,
+                                "Open-ended exploration of ideas, options, or possibilities; less structured than investigate.",
+                                "User wants to explore a space of ideas or options without a fixed question.",
+                                "When the goal is systematic investigation (INVESTIGATE) or synthesis (SYNTHESIZE).",
+                                "EXPLORE = open exploration; INVESTIGATE = systematic; SYNTHESIZE = combine into one.",
+                                "Structured exploration; multiple angles or options.",
+                                List.of(PromptCategory.RESEARCH, PromptCategory.CREATIVE),
+                                List.of("IDEA_GENERATION", "LITERATURE_REVIEW"),
+                                List.of("RESEARCHER", "CREATIVE_DIRECTOR"),
+                                "Less formal than INVESTIGATE; fits creative and research."
+                        )
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResearchIntentResolutionDefaultsProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResearchIntentResolutionDefaultsProvider.java
@@ -1,0 +1,30 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+
+import java.util.List;
+
+final class IntentResearchIntentResolutionDefaultsProvider implements IntentResolutionDefaultsEntriesProvider {
+
+    @Override
+    public List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries() {
+        return List.of(
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.INVESTIGATE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.SYNTHESIZE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.STRUCTURED_TEXT, ResponseShape.STRUCTURED)
+                ),
+                new IntentDefinitionDataSource.IntentResolutionDefaultEntry(
+                        ActionIntent.EXPLORE,
+                        new IntentResolutionDefaults(PromptObjective.REASONING, OutputNeeds.FREE_FORM, ResponseShape.STRUCTURED)
+                )
+        );
+    }
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResolutionDefaults.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResolutionDefaults.java
@@ -1,0 +1,18 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import org.example.sharedprompts.domain.prompt.common.enums.output.OutputNeeds;
+import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptObjective;
+import org.example.sharedprompts.domain.prompt.common.enums.output.ResponseShape;
+
+/**
+ * Intent별 semantic resolution 기본값 (objective / output needs / response shape).
+ * <p>
+ * {@link org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent} enum에는 정책이 없고,
+ * 실제 기본값은 {@link IntentDictionary}에서 제공한다.
+ */
+public record IntentResolutionDefaults(
+        PromptObjective defaultObjective,
+        OutputNeeds preferredOutputNeeds,
+        ResponseShape defaultResponseShape
+) {}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResolutionDefaultsEntriesProvider.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/IntentResolutionDefaultsEntriesProvider.java
@@ -1,0 +1,14 @@
+package org.example.sharedprompts.domain.prompt.domain.semantic;
+
+import java.util.List;
+
+/**
+ * Provides intent resolution-default entries (objective / output needs / response shape).
+ * <p>
+ * Data ownership lives in providers; {@link IntentDefinitionDataSource} only aggregates.
+ */
+interface IntentResolutionDefaultsEntriesProvider {
+
+    List<IntentDefinitionDataSource.IntentResolutionDefaultEntry> entries();
+}
+

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/impl/DefaultCategorySemanticProfileRegistry.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/impl/DefaultCategorySemanticProfileRegistry.java
@@ -40,15 +40,10 @@ public class DefaultCategorySemanticProfileRegistry implements CategorySemanticP
     private final CanonicalActionRegistry canonicalActionRegistry;
     private final CompatibilityPolicySource compatibilityPolicySource;
 
-    /** Uses default in-memory seed source. */
-    public DefaultCategorySemanticProfileRegistry(CanonicalActionRegistry canonicalActionRegistry) {
-        this(canonicalActionRegistry, null);
-    }
-
-    /** With optional compatibility policy source; uses default seed source. */
+    /** Convenience overload with no compatibility source. */
     public DefaultCategorySemanticProfileRegistry(CanonicalActionRegistry canonicalActionRegistry,
-                                                   CompatibilityPolicySource compatibilityPolicySource) {
-        this(canonicalActionRegistry, compatibilityPolicySource, new DefaultCategorySemanticProfileSeedSource());
+                                                 CategorySemanticProfileSeedSource seedSource) {
+        this(canonicalActionRegistry, null, seedSource);
     }
 
     /** Full constructor: assembles profiles from seed source; compatibility source overrides group keys when non-empty. */

--- a/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/impl/DefaultCategorySemanticProfileSeedSource.java
+++ b/sharedPrompts/src/main/java/org/example/sharedprompts/domain/prompt/domain/semantic/impl/DefaultCategorySemanticProfileSeedSource.java
@@ -40,40 +40,39 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Default in-memory profile seed source. Owns category/intent action and role seed data;
  * registry assembles profiles from this, not from inline register* methods.
  */
 public class DefaultCategorySemanticProfileSeedSource implements CategorySemanticProfileSeedSource {
-
-    private static final Set<PromptCategory> PROFILE_CATEGORIES = Set.of(
-            PromptCategory.DESIGN, PromptCategory.DEVELOPMENT, PromptCategory.WRITING, PromptCategory.RESEARCH,
-            PromptCategory.BUSINESS, PromptCategory.PRODUCTIVITY, PromptCategory.DATA_ANALYSIS, PromptCategory.MARKETING,
-            PromptCategory.CUSTOMER_SUPPORT, PromptCategory.CREATIVE, PromptCategory.LEGAL, PromptCategory.EDUCATION, PromptCategory.ETC
+    private static final Map<PromptCategory, Supplier<CategorySemanticProfileSeed>> SEED_SUPPLIERS = Map.ofEntries(
+            Map.entry(PromptCategory.DESIGN, DefaultCategorySemanticProfileSeedSource::buildDesign),
+            Map.entry(PromptCategory.DEVELOPMENT, DefaultCategorySemanticProfileSeedSource::buildDevelopment),
+            Map.entry(PromptCategory.WRITING, DefaultCategorySemanticProfileSeedSource::buildWriting),
+            Map.entry(PromptCategory.RESEARCH, DefaultCategorySemanticProfileSeedSource::buildResearch),
+            Map.entry(PromptCategory.BUSINESS, DefaultCategorySemanticProfileSeedSource::buildBusiness),
+            Map.entry(PromptCategory.PRODUCTIVITY, DefaultCategorySemanticProfileSeedSource::buildProductivity),
+            Map.entry(PromptCategory.MARKETING, DefaultCategorySemanticProfileSeedSource::buildMarketing),
+            Map.entry(PromptCategory.CUSTOMER_SUPPORT, DefaultCategorySemanticProfileSeedSource::buildCustomerSupport),
+            Map.entry(PromptCategory.DATA_ANALYSIS, DefaultCategorySemanticProfileSeedSource::buildDataAnalysis),
+            Map.entry(PromptCategory.LEGAL, DefaultCategorySemanticProfileSeedSource::buildLegal),
+            Map.entry(PromptCategory.CREATIVE, DefaultCategorySemanticProfileSeedSource::buildCreative),
+            Map.entry(PromptCategory.EDUCATION, DefaultCategorySemanticProfileSeedSource::buildEducation),
+            Map.entry(PromptCategory.ETC, DefaultCategorySemanticProfileSeedSource::buildEtc)
     );
 
     @Override
     public Optional<CategorySemanticProfileSeed> getSeed(PromptCategory category) {
-        if (category == null || !PROFILE_CATEGORIES.contains(category)) {
+        if (category == null) {
             return Optional.empty();
         }
-        return switch (category) {
-            case DESIGN -> Optional.of(buildDesign());
-            case DEVELOPMENT -> Optional.of(buildDevelopment());
-            case WRITING -> Optional.of(buildWriting());
-            case RESEARCH -> Optional.of(buildResearch());
-            case BUSINESS -> Optional.of(buildBusiness());
-            case PRODUCTIVITY -> Optional.of(buildProductivity());
-            case MARKETING -> Optional.of(buildMarketing());
-            case CUSTOMER_SUPPORT -> Optional.of(buildCustomerSupport());
-            case DATA_ANALYSIS -> Optional.of(buildDataAnalysis());
-            case LEGAL -> Optional.of(buildLegal());
-            case CREATIVE -> Optional.of(buildCreative());
-            case EDUCATION -> Optional.of(buildEducation());
-            case ETC -> Optional.of(buildEtc());
-            default -> Optional.empty();
-        };
+        Supplier<CategorySemanticProfileSeed> supplier = SEED_SUPPLIERS.get(category);
+        if (supplier == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(supplier.get());
     }
 
     private static CategorySemanticProfileSeed buildDesign() {

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/CategorySemanticProfileSeedSourceAssemblerTest.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/CategorySemanticProfileSeedSourceAssemblerTest.java
@@ -1,7 +1,6 @@
 package org.example.sharedprompts.domain.prompt.domain.semantic;
 
 import org.example.sharedprompts.domain.prompt.common.enums.DeserializerEnumTestUtils;
-import org.example.sharedprompts.domain.prompt.common.enums.action.ActionTypeInterface;
 import org.example.sharedprompts.domain.prompt.common.enums.action.canonical.ActionGroup;
 import org.example.sharedprompts.domain.prompt.common.enums.action.canonical.CanonicalActionRegistry;
 import org.example.sharedprompts.domain.prompt.common.enums.action.canonical.DefaultCanonicalActionRegistry;
@@ -21,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -119,11 +117,12 @@ class CategorySemanticProfileSeedSourceAssemblerTest {
     }
 
     @Test
-    @DisplayName("Two-arg registry constructor uses default seed source and preserves behavior")
-    void twoArgConstructorUsesDefaultSource() {
+    @DisplayName("Registry requires external seed source (no internal default new)")
+    void registryRequiresExternalSeedSource() {
         ActionTypeRegistry actionRegistry = new ActionTypeRegistry(CATALOG);
         CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(actionRegistry);
-        DefaultCategorySemanticProfileRegistry registry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileSeedSource defaultSource = new DefaultCategorySemanticProfileSeedSource();
+        DefaultCategorySemanticProfileRegistry registry = new DefaultCategorySemanticProfileRegistry(canonical, defaultSource);
 
         CategorySemanticProfile profile = registry.getProfile(PromptCategory.WRITING).orElseThrow();
         assertThat(profile.getCategory()).isEqualTo(PromptCategory.WRITING);

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/ProfileCanonicalFirstTest.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/ProfileCanonicalFirstTest.java
@@ -9,6 +9,7 @@ import org.example.sharedprompts.domain.prompt.common.enums.action.canonical.Def
 import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionIntent;
 import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
 import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileRegistry;
+import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileSeedSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +28,7 @@ class ProfileCanonicalFirstTest {
     private final CanonicalActionRegistry registry = new DefaultCanonicalActionRegistry(
             new ActionTypeRegistry(DeserializerEnumTestUtils.getActionTypeEnums()));
     private final DefaultCategorySemanticProfileRegistry profileRegistry =
-            new DefaultCategorySemanticProfileRegistry(registry);
+            new DefaultCategorySemanticProfileRegistry(registry, new DefaultCategorySemanticProfileSeedSource());
 
     @Test
     @DisplayName("profile returns non-empty action groups for intent when category has actions")

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/SemanticStructurePhase3Test.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/SemanticStructurePhase3Test.java
@@ -10,11 +10,14 @@ import org.example.sharedprompts.domain.prompt.common.enums.semantic.ActionInten
 import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCategory;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveMappingRegistry;
 import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileRegistry;
+import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileSeedSource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.objective.DefaultObjectivePolicySource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.objective.ObjectivePolicySource;
 import org.example.sharedprompts.domain.prompt.domain.value.objective.PromptObjective;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import org.example.sharedprompts.domain.prompt.domain.resolutions.DefaultObjectiveHeuristicInferencePolicy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,9 +42,11 @@ class SemanticStructurePhase3Test {
         Collections.reverse(reversed);
         ActionTypeRegistry registryReversed = new ActionTypeRegistry(reversed);
 
-        DefaultCategorySemanticProfileRegistry profileOrderA = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileOrderA = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         DefaultCategorySemanticProfileRegistry profileOrderB = new DefaultCategorySemanticProfileRegistry(
-                new DefaultCanonicalActionRegistry(registryReversed));
+                new DefaultCanonicalActionRegistry(registryReversed),
+                new DefaultCategorySemanticProfileSeedSource());
 
         for (PromptCategory category : List.of(PromptCategory.WRITING, PromptCategory.DEVELOPMENT, PromptCategory.RESEARCH)) {
             var profA = profileOrderA.getProfile(category);
@@ -61,9 +66,9 @@ class SemanticStructurePhase3Test {
     @DisplayName("Objective mapping works by stable key without concrete enum reference")
     void objectiveMappingByStableKey() {
         ActionTypeRegistry actionTypeRegistry = new ActionTypeRegistry(CATALOG);
-        CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(actionTypeRegistry);
         ObjectivePolicySource source = new DefaultObjectivePolicySource(Map.of());
-        ObjectiveMappingRegistry mapping = new ObjectiveMappingRegistry(canonical, source);
+        ObjectiveMappingRegistry mapping =
+                new ObjectiveMappingRegistry(source, new DefaultObjectiveHeuristicInferencePolicy());
 
         mapping.putByStableKey("ACTION.CODING.CODE_REVIEW", PromptObjective.REASONING);
         mapping.putByStableKey("ACTION.WRITING.TRANSLATION", PromptObjective.FACTUAL);
@@ -80,9 +85,9 @@ class SemanticStructurePhase3Test {
     @DisplayName("New action key can be added to policy without changing config class")
     void extensibilityByStableKeyOnly() {
         ActionTypeRegistry actionTypeRegistry = new ActionTypeRegistry(CATALOG);
-        CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(actionTypeRegistry);
         ObjectivePolicySource source = new DefaultObjectivePolicySource(Map.of());
-        ObjectiveMappingRegistry mapping = new ObjectiveMappingRegistry(canonical, source);
+        ObjectiveMappingRegistry mapping =
+                new ObjectiveMappingRegistry(source, new DefaultObjectiveHeuristicInferencePolicy());
 
         String someExistingKey = "ACTION.CODING.DEBUGGING";
         mapping.putByStableKey(someExistingKey, PromptObjective.REASONING);

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/policy/SemanticStructurePhase4Test.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/policy/SemanticStructurePhase4Test.java
@@ -11,6 +11,7 @@ import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCateg
 import org.example.sharedprompts.domain.prompt.domain.semantic.CategorySemanticProfile;
 import org.example.sharedprompts.domain.prompt.domain.semantic.RecommendationResult;
 import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileRegistry;
+import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileSeedSource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.ActionRecommendationOrderPolicy;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.ActionRecommendationPreferenceSource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.ConcreteActionByGroupIndex;
@@ -52,7 +53,8 @@ class SemanticStructurePhase4Test {
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
 
         DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
-                new DefaultCanonicalActionRegistry(registry));
+                new DefaultCanonicalActionRegistry(registry),
+                new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
         Set<ActionGroup> groups = Set.copyOf(profile.getCompatibleActionGroupsForIntent(ActionIntent.GENERATE));
         List<ActionTypeInterface> seeds = profile.getCompatibleActionsForIntent(ActionIntent.GENERATE);
@@ -85,7 +87,8 @@ class SemanticStructurePhase4Test {
         ActionRecommendationOrderPolicy orderPolicy = new DefaultActionRecommendationOrderPolicy(pref);
 
         DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
-                new DefaultCanonicalActionRegistry(registry));
+                new DefaultCanonicalActionRegistry(registry),
+                new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
         List<ActionTypeInterface> expanded = expander.expand(
                 PromptCategory.WRITING,
@@ -119,7 +122,8 @@ class SemanticStructurePhase4Test {
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
 
         DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
-                new DefaultCanonicalActionRegistry(registry));
+                new DefaultCanonicalActionRegistry(registry),
+                new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.DEVELOPMENT).orElseThrow();
         Set<ActionGroup> groups = Set.copyOf(profile.getCompatibleActionGroupsForIntent(ActionIntent.GENERATE));
 
@@ -144,7 +148,8 @@ class SemanticStructurePhase4Test {
         ConcreteActionByGroupIndex index = new DefaultConcreteActionByGroupIndex(registry.getAll());
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
 
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         SemanticRecommendationService serviceWriting = serviceWithPreference(Map.of(
                 "WRITING+GENERATE", List.of("ACTION.WRITING.ARTICLE_WRITING", "ACTION.WRITING.CREATIVE_WRITING_GEN")
         ), index, expander);
@@ -174,7 +179,8 @@ class SemanticStructurePhase4Test {
         ActionRecommendationOrderPolicy policyNoPref = new DefaultActionRecommendationOrderPolicy(noPref);
 
         DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
-                new DefaultCanonicalActionRegistry(registry));
+                new DefaultCanonicalActionRegistry(registry),
+                new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
         List<ActionTypeInterface> expanded = expander.expand(
                 PromptCategory.WRITING,
@@ -205,7 +211,8 @@ class SemanticStructurePhase4Test {
 
         CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(registry);
         SemanticRecommendationService service = new SemanticRecommendationService(canonical, expander, policySourceRegistry, strategy);
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
 
         RecommendationResult result = service.recommend(PromptCategory.WRITING, ActionIntent.GENERATE, profile, null, null, false);

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/policy/SemanticStructurePhase5Test.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/policy/SemanticStructurePhase5Test.java
@@ -12,6 +12,7 @@ import org.example.sharedprompts.domain.prompt.common.enums.semantic.TaskDomain;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveMappingRegistry;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveResolver;
 import org.example.sharedprompts.domain.prompt.domain.resolutions.ObjectiveResolverPort;
+import org.example.sharedprompts.domain.prompt.domain.resolutions.DefaultObjectiveHeuristicInferencePolicy;
 import org.example.sharedprompts.domain.prompt.domain.semantic.CategorySemanticProfile;
 import org.example.sharedprompts.domain.prompt.domain.semantic.CategorySemanticProfileSeedSource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.RecommendationResult;
@@ -21,16 +22,13 @@ import org.example.sharedprompts.domain.prompt.domain.semantic.policy.compatibil
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.compatibility.DefaultCompatibilityPolicySource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.objective.DefaultObjectivePolicySource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.objective.ObjectivePolicySource;
-import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.ActionRecommendationOrderPolicy;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.ActionRecommendationPreferenceSource;
-import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.DefaultActionRecommendationOrderPolicy;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.DefaultActionRecommendationPreferenceSource;
 import org.example.sharedprompts.domain.prompt.domain.value.objective.PromptObjective;
 import org.example.sharedprompts.domain.prompt.application.semantic.policy.PolicySelectionStrategy;
 import org.example.sharedprompts.domain.prompt.application.semantic.recommendation.PolicyTestFixtures;
 import org.example.sharedprompts.domain.prompt.application.semantic.recommendation.SemanticRecommendationService;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.registry.PolicySourceRegistry;
-import org.example.sharedprompts.domain.prompt.domain.semantic.policy.version.PolicyVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +56,8 @@ class SemanticStructurePhase5Test {
         org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.RecommendationConcreteActionExpander expander =
                 new org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.DefaultRecommendationConcreteActionExpander(index);
 
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
 
         PolicySourceRegistry registryA = PolicyTestFixtures.registryWithSingleVersion(new DefaultActionRecommendationPreferenceSource());
@@ -85,10 +84,10 @@ class SemanticStructurePhase5Test {
     @DisplayName("Objective resolution uses policy source; swapping source changes mapping")
     void objectiveResolutionUsesPolicySource() {
         ActionTypeRegistry registry = new ActionTypeRegistry(CATALOG);
-        CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(registry);
 
         ObjectivePolicySource sourceDefault = new DefaultObjectivePolicySource();
-        ObjectiveMappingRegistry registryDefault = new ObjectiveMappingRegistry(canonical, sourceDefault);
+        ObjectiveMappingRegistry registryDefault =
+                new ObjectiveMappingRegistry(sourceDefault, new DefaultObjectiveHeuristicInferencePolicy());
         ObjectiveResolverPort resolverDefault = new ObjectiveResolver(registryDefault);
 
         Map<String, PromptObjective> customMap = Map.of(
@@ -96,7 +95,8 @@ class SemanticStructurePhase5Test {
                 "ACTION.WRITING.TRANSLATION", PromptObjective.CREATIVE_WITH_CONSTRAINTS
         );
         ObjectivePolicySource sourceCustom = new DefaultObjectivePolicySource(customMap);
-        ObjectiveMappingRegistry registryCustom = new ObjectiveMappingRegistry(canonical, sourceCustom);
+        ObjectiveMappingRegistry registryCustom =
+                new ObjectiveMappingRegistry(sourceCustom, new DefaultObjectiveHeuristicInferencePolicy());
         ObjectiveResolverPort resolverCustom = new ObjectiveResolver(registryCustom);
 
         ActionTypeInterface codeReview = registry.getByStableKey("ACTION.CODING.CODE_REVIEW");
@@ -149,9 +149,9 @@ class SemanticStructurePhase5Test {
                 Map.of("WRITING+GENERATE", List.of("LONG_FORM_WRITING", "CREATIVE_WRITING", "SHORT_COPY"))
         );
         DefaultCategorySemanticProfileRegistry profileRegistryWithSource =
-                new DefaultCategorySemanticProfileRegistry(canonical, compatibilitySource);
+                new DefaultCategorySemanticProfileRegistry(canonical, compatibilitySource, new DefaultCategorySemanticProfileSeedSource());
         DefaultCategorySemanticProfileRegistry profileRegistryNoSource =
-                new DefaultCategorySemanticProfileRegistry(canonical);
+                new DefaultCategorySemanticProfileRegistry(canonical, new DefaultCategorySemanticProfileSeedSource());
 
         CategorySemanticProfile profileWith = profileRegistryWithSource.getProfile(PromptCategory.WRITING).orElseThrow();
         CategorySemanticProfile profileWithout = profileRegistryNoSource.getProfile(PromptCategory.WRITING).orElseThrow();

--- a/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/policy/SemanticStructurePhase6Test.java
+++ b/sharedPrompts/src/test/java/org/example/sharedprompts/domain/prompt/domain/semantic/policy/SemanticStructurePhase6Test.java
@@ -9,6 +9,7 @@ import org.example.sharedprompts.domain.prompt.common.enums.semantic.PromptCateg
 import org.example.sharedprompts.domain.prompt.domain.semantic.CategorySemanticProfile;
 import org.example.sharedprompts.domain.prompt.domain.semantic.RecommendationResult;
 import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileRegistry;
+import org.example.sharedprompts.domain.prompt.domain.semantic.impl.DefaultCategorySemanticProfileSeedSource;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.ConcreteActionByGroupIndex;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.DefaultConcreteActionByGroupIndex;
 import org.example.sharedprompts.domain.prompt.domain.semantic.policy.recommendation.DefaultRecommendationConcreteActionExpander;
@@ -47,7 +48,8 @@ class SemanticStructurePhase6Test {
         CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(registry);
         ConcreteActionByGroupIndex index = new DefaultConcreteActionByGroupIndex(registry.getAll());
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
 
         RolePreferenceSource emptyRolePref = new DefaultRolePreferenceSource();
@@ -93,7 +95,8 @@ class SemanticStructurePhase6Test {
         CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(registry);
         ConcreteActionByGroupIndex index = new DefaultConcreteActionByGroupIndex(registry.getAll());
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
 
         Map<String, List<String>> roleOrder = Map.of(
@@ -124,7 +127,8 @@ class SemanticStructurePhase6Test {
         CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(registry);
         ConcreteActionByGroupIndex index = new DefaultConcreteActionByGroupIndex(registry.getAll());
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
 
         Map<String, List<String>> rolePref = Map.of("WRITING+GENERATE", List.of("ROLE.WRITING.COPYWRITER"));
@@ -154,7 +158,8 @@ class SemanticStructurePhase6Test {
         CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(registry);
         ConcreteActionByGroupIndex index = new DefaultConcreteActionByGroupIndex(registry.getAll());
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
 
         PolicySourceRegistry policyRegistry = PolicyTestFixtures.registryWithSingleVersion(
@@ -206,7 +211,8 @@ class SemanticStructurePhase6Test {
         CanonicalActionRegistry canonical = new DefaultCanonicalActionRegistry(registry);
         ConcreteActionByGroupIndex index = new DefaultConcreteActionByGroupIndex(registry.getAll());
         RecommendationConcreteActionExpander expander = new DefaultRecommendationConcreteActionExpander(index);
-        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(canonical);
+        DefaultCategorySemanticProfileRegistry profileRegistry = new DefaultCategorySemanticProfileRegistry(
+                canonical, new DefaultCategorySemanticProfileSeedSource());
         CategorySemanticProfile profile = profileRegistry.getProfile(PromptCategory.WRITING).orElseThrow();
         PolicySourceRegistry policyRegistry = PolicyTestFixtures.registryWithSingleVersion(
                 new DefaultActionRecommendationPreferenceSource(Map.of("WRITING+GENERATE", List.of("ACTION.WRITING.ARTICLE_WRITING", "ACTION.WRITING.COPYWRITING"))),


### PR DESCRIPTION
Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 의도(Intent) 정의 및 해석 기본값 시스템을 모듈식 공급자 기반 아키텍처로 재설계하여 유지보수성 개선
  * 8가지 의도 카테고리(분석, 생성, 의사결정, 설명, 추출, 수정, 계획, 연구)에 대한 의도 해석 구조 재구성
  * 의도 사전 및 관련 구성 요소 내부 구조 개선

* **테스트**
  * 리팩토링된 의도 아키텍처를 반영하도록 시맨틱 테스트 스위트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->